### PR TITLE
update) run_unit_test.sh

### DIFF
--- a/test/unit_test/run_unit_test.sh
+++ b/test/unit_test/run_unit_test.sh
@@ -18,16 +18,17 @@ RESET='\033[0m'
 
 # func
 exec_make() {
-    if "${MAKE_OUTPUT}"; then
-        make -C $1
-    else
-        make -C $1 >/dev/null 2>&1
-    fi
+    make_log=$(make -C $1 2>&1)
 
     if [ $? -eq $MAKE_FAILURE ]; then
         make_res=$EXIT_FAILURE
     else
         make_res=$EXIT_SUCCESS
+    fi
+
+    # if make failure, output log
+    if "${MAKE_OUTPUT}" || [ $make_res -eq $EXIT_FAILURE ]; then
+        echo "$make_log"
     fi
 
     put_result $make_res " Make : "


### PR DESCRIPTION
- [x] Make 失敗時にerror logを必ず表示するよう変更
  -> actionsでのmake errorの原因を、shの設定を変更する手間なく、actionsのログで確認できるようになった

<br>

* 前提
  * Makeのログは`MAKE_OUTPUT=true/false`で設定できる
  * ログが流れるため通常は非表示(`MAKE_OUTPUT=false`)にしている
* before
  * localではmake成功、Actionsではmake失敗するケースがあり、エラー因をチェックするため、MAKE_OUTPUTを変更し再度pushする手間が生じる
* after
  * Actionsのログを見るだけ

---

* 挙動の確認方法
  - `bash test/unit_test/run_unit_test.sh`で実行
  - 本ブランチは`test/unit_test/hoge`が実行対象になっているため、`test/unit_test/hoge/test_main.cpp`などを変更すればエラー時の挙動もチェック可能
