### PR TITLE
fix) Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,15 +28,13 @@ INCLUDES	 =	$(addprefix -I, $(INCLUDES_DIR))
 
 # RULES ------------------------------------------------------------------------
 .PHONY	: all
-all		: $(OBJS_DIR) $(NAME)
+all		: $(NAME)
 
 $(NAME)	: $(OBJS)
 	$(CXX) $(CXXFLAGS) -o $@ $^
 
-$(OBJS_DIR)		:
-	@mkdir -p $@
-
 $(OBJS_DIR)/%.o	: $(SRCS_DIR)/%.cpp
+	@mkdir -p $$(dirname $@)
 	$(CXX) $(CXXFLAGS) $(INCLUDES) -c -o $@ $<
 
 .PHONY	: clean


### PR DESCRIPTION
* objs以下のディレクトリが作成され図、`.o`の作成をミスっている点を修正
  * `srcs/Socket/Socket.cpp`など、`srcs/`以下にあるディレクトリ内の`.cpp`から`.o`を作成する際、objs/は作成するが`Objs/Socket/`は作成しない
    -> `objs/Socket/Socket.o`が作成されない

