### PR TITLE
implement) server

### DIFF
--- a/.github/workflows/gtest.yml
+++ b/.github/workflows/gtest.yml
@@ -1,42 +1,82 @@
 name: UNIT_TEST
 on: [push]
 jobs:
-  Linux:
+  Linux_select:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
 
       - name: build
         run: |
-          cmake -S . -B build -DCUSTOM_FLAGS="-D DEBUG"
+          cmake -S . -B build -DCUSTOM_FLAGS="-D USE_SELECT_MULTIPLEXER"
           cmake --build build
 
       - name: run all tests on Linux
-        run: ./build/unit_test
+        run: ./build/unit_test 2>/dev/null
 
       - uses: sarisia/actions-status-discord@v1
         if: always()
         with:
-          title: "UNIT_TEST_ON_LINUX"
+          title: "[UNIT_TEST] SELECT Ver. (on Linux)"
           webhook: ${{ secrets.DISCORD_WEBHOOK }}
           status: ${{ job.status }}
 
-  macOS:
+  Linux_epoll:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: build
+        run: |
+          cmake -S . -B build
+          cmake --build build
+
+      - name: run all tests on Linux
+        run: ./build/unit_test 2>/dev/null
+
+      - uses: sarisia/actions-status-discord@v1
+        if: always()
+        with:
+          title: "[UNIT_TEST] EPOLL Ver. (on Linux)"
+          webhook: ${{ secrets.DISCORD_WEBHOOK }}
+          status: ${{ job.status }}
+
+  macOS_select:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
 
       - name: build
         run: |
-          cmake -S . -B build -DCUSTOM_FLAGS="-D DEBUG"
+          cmake -S . -B build -DCUSTOM_FLAGS="-D USE_SELECT_MULTIPLEXER"
           cmake --build build
 
       - name: run all tests on macOS
-        run: ./build/unit_test
+        run: ./build/unit_test 2>/dev/null
 
       - uses: sarisia/actions-status-discord@v1
         if: always()
         with:
-          title: "UNIT_TEST_ON_MACOS"
+          title: "[UNIT_TEST] SELECT Ver. (on macOS)"
+          webhook: ${{ secrets.DISCORD_WEBHOOK }}
+          status: ${{ job.status }}
+
+  macOS_kqueue:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: build
+        run: |
+          cmake -S . -B build
+          cmake --build build
+
+      - name: run all tests on macOS
+        run: ./build/unit_test 2>/dev/null
+
+      - uses: sarisia/actions-status-discord@v1
+        if: always()
+        with:
+          title: "[UNIT TEST] KQUEUE Ver. (on macOS)"
           webhook: ${{ secrets.DISCORD_WEBHOOK }}
           status: ${{ job.status }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,8 @@
 *
 
-!.gitignore
 !.github
 !.github/*
+!.gitignore
 !config
 
 !srcs
@@ -11,24 +11,25 @@
 !srcs/Error
 !srcs/Server
 !srcs/Socket
-!www
 !includes
-!test
 !playground
+!test
+!www
 
-!*.cpp
-!*.hpp
-!*.yml
 !*.conf
-!*.txt
+!*.cpp
 !*.h
+!*.hpp
+!*.txt
+!*.yml
 
-!Readme.md
-!Makefile
 !CPPLINT.cfg
-!webserv.drawio
 !CMakeLists.txt
+!Makefile
+!Readme.md
+!webserv.drawio
 
+.DS_Store
 .idea
 .vscode
 client_response.txt

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 !srcs
 !srcs/Debug
 !srcs/Error
+!srcs/Server
 !srcs/Socket
 !www
 !includes

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 !config
 
 !srcs
+!srcs/Client
 !srcs/Debug
 !srcs/Error
 !srcs/Server
@@ -30,6 +31,6 @@
 
 .idea
 .vscode
-.DS_Store
+client_response.txt
 CMakeCache.txt
 Dockerfile

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,12 +6,12 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_FLAGS "-Wall -Wextra -Werror -pedantic")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -fsanitize=address,undefined -fno-omit-frame-pointer")
 
-#set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D DEBUG")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D DEBUG")
+#set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D USE_SELECT_MULTIPLEXER")
 
 if(DEFINED CUSTOM_FLAGS)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CUSTOM_FLAGS}")
 endif()
-
 
 # google test ------------------------------------------------------------------
 include(FetchContent)
@@ -32,18 +32,24 @@ enable_testing()
 # includes ---------------------------------------------------------------------
 include_directories(
         includes
+        srcs/Client
         srcs/Debug
         srcs/Error
+        srcs/IOMultiplexer
+        srcs/Server
         srcs/Socket
 )
 
 # webserv_srcs -----------------------------------------------------------------
 set(webserv_srcs
         srcs/get_valid_config_file_path.cpp
+        srcs/Client/Client.cpp
         srcs/Debug/Debug.cpp
         srcs/Error/Error.cpp
+        srcs/IOMultiplexer/IOMultiplexer.cpp
+        srcs/Server/Server.cpp
         srcs/Socket/Socket.cpp
-)
+        )
 
 add_executable(webserv
         srcs/main.cpp
@@ -53,10 +59,11 @@ add_executable(webserv
 # unit_test_srcs ---------------------------------------------------------------
 set (unit_test_srcs
         test/unit_test/is_valid_file_path/test_get_valid_config_file_path.cpp
-        test/unit_test/TestError.cpp
         test/unit_test/TestResult.cpp
+        test/unit_test/TestServer.cpp
         test/unit_test/TestSocket.cpp
-)
+        test/unit_test/TestError.cpp
+        )
 
 add_executable(unit_test
         ${webserv_srcs}

--- a/Makefile
+++ b/Makefile
@@ -130,8 +130,8 @@ run_result_test	:
 	cmake --build build
 	./build/unit_test --gtest_filter=Result*
 
-.PHONY	: run_err_test
-run_err_test	:
+.PHONY	: run_errmsg_test
+run_errmsg_test	:
 	#rm -rf build
 	cmake -S . -B build -DCUSTOM_FLAGS="-D DEBUG"
 	cmake --build build

--- a/Makefile
+++ b/Makefile
@@ -106,6 +106,23 @@ run_unit_test	:
 	./build/unit_test 2>/dev/null
 	#./build/unit_test
 
+.PHONY	: run_server_test
+run_server_test	:
+	#rm -rf build
+	cmake -S . -B build -DCUSTOM_FLAGS="-D DEBUG"
+	#cmake -S . -B build -DCUSTOM_FLAGS="-D DEBUG -D USE_SELECT_MULTIPLEXER"
+	cmake --build build
+	#./build/unit_test --gtest_filter=Server* 2>/dev/null
+	./build/unit_test --gtest_filter=Server*
+	#./build/unit_test --gtest_filter=*.ConnectClientCase1
+
+.PHONY	: run_socket_test
+run_socket_test	:
+	#rm -rf build
+	cmake -S . -B build
+	cmake --build build
+	./build/unit_test --gtest_filter=Socket* 2>/dev/null
+
 .PHONY	: run_result_test
 run_result_test	:
 	#rm -rf build

--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,13 @@ OBJS		=	$(SRCS:%.cpp=$(OBJS_DIR)/%.o)
 DEPS		=	$(OBJS:%.o=%.d)
 
 
+# CLIENT -----------------------------------------------------------------------
+CLIENT_DIR	=	Client
+CLIENT_SRC	=	$(CLIENT_DIR)/Client.cpp \
+				$(CLIENT_DIR)/client_main.cpp
+CLIENT_OBJ	=	$(CLIENT_SRC:%.cpp=%.o)
+CLIENT_OBJS	=	$(addprefix $(OBJS_DIR)/, $(CLIENT_OBJ))
+
 # INCLUDES ---------------------------------------------------------------------
 INCLUDES_DIR =	includes \
 				$(SRCS_DIR)/$(IO_DIR) \
@@ -81,7 +88,7 @@ clean	:
 
 .PHONY	: fclean
 fclean	: clean
-	rm -f $(NAME)
+	rm -f $(NAME) client
 
 .PHONY	: re
 re		: fclean all
@@ -113,12 +120,8 @@ run_err_test	:
 	cmake --build build
 	./build/unit_test --gtest_filter=ErrorMessage*
 
-.PHONY	: run_socket_test
-run_socket_test	:
-	#rm -rf build
-	cmake -S . -B build -DCUSTOM_FLAGS="-D DEBUG"
-	cmake --build build
-	./build/unit_test --gtest_filter=SocketUnitTest.*:SocketIntegrationTest.*
-
+.PHONY	: client
+client	: $(CLIENT_OBJS)
+	$(CXX) $(CXXFLAGS) -o $@ $^
 
 -include $(DEPS)

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ NAME		=	webserv
 CXX			=	c++
 CXXFLAGS	=	-std=c++98 -Wall -Wextra -Werror -MMD -MP
 CXXFLAGS	+=	-g -fsanitize=address,undefined -fno-omit-frame-pointer
+#CXXFLAGS	+=	-D USE_SELECT_MULTIPLEXER
 
 # SRCS -------------------------------------------------------------------------
 SRCS_DIR	=	srcs
@@ -10,6 +11,25 @@ SRCS_DIR	=	srcs
 #main
 SRCS		=	main.cpp \
 				get_valid_config_file_path.cpp
+#debug
+DEBUG_DIR	=	Debug
+SRCS		+=	$(DEBUG_DIR)/Debug.cpp
+
+#error
+ERROR_DIR	=	Error
+SRCS		+=	$(ERROR_DIR)/Error.cpp
+
+#io
+IO_DIR		=	IOMultiplexer
+SRCS		+=	$(IO_DIR)/IOMultiplexer.cpp
+
+#server
+SERVER_DIR	=	Server
+SRCS		+=	$(SERVER_DIR)/Server.cpp
+
+#socket
+SOCKET_DIR	=	Socket
+SRCS		+=	$(SOCKET_DIR)/Socket.cpp
 
 #error
 ERROR_DIR	=	Error
@@ -35,8 +55,10 @@ DEPS		=	$(OBJS:%.o=%.d)
 
 # INCLUDES ---------------------------------------------------------------------
 INCLUDES_DIR =	includes \
+				$(SRCS_DIR)/$(IO_DIR) \
 				$(SRCS_DIR)/$(DEBUG_DIR) \
 				$(SRCS_DIR)/$(ERROR_DIR) \
+				$(SRCS_DIR)/$(SERVER_DIR) \
 				$(SRCS_DIR)/$(SOCKET_DIR)
 
 INCLUDES	 =	$(addprefix -I, $(INCLUDES_DIR))

--- a/includes/webserv.hpp
+++ b/includes/webserv.hpp
@@ -1,5 +1,5 @@
 #pragma once
 
-#include <string>
+# include <string>
 
 std::string get_valid_config_file_path(const char *path);

--- a/playground/map_template.cpp
+++ b/playground/map_template.cpp
@@ -1,0 +1,70 @@
+#include <iostream>
+#include <map>
+
+class MapValueBase {
+ public:
+	virtual ~MapValueBase() {}
+};
+
+class SingleStringValue : public MapValueBase{
+ public:
+	SingleStringValue() {}
+	SingleStringValue(const std::string &value) :  _value(value) {}
+	virtual~SingleStringValue() {}
+	virtual std::string get_value() { return _value; }
+
+ private:
+	std::string _value;
+};
+
+class MultiStringValue : public MapValueBase{
+ public:
+	MultiStringValue(const std::string &value1,
+					 const std::string &value2) : _value1(value1),
+												  _value2(value2) {}
+	virtual~MultiStringValue() {}
+	std::string get_value1() { return _value1; }
+	std::string get_value2() { return _value2; }
+
+ private:
+	std::string _value1;
+	std::string _value2;
+};
+
+class NumValue : public MapValueBase {
+ public:
+	NumValue(int num) : _value(num) {}
+	virtual ~NumValue() {}
+	int get_value() { return _value; }
+
+ private:
+	int _value;
+};
+
+void print_value(const std::string &key, MapValueBase *value) {
+	if (key == "single") {
+		SingleStringValue *ptr = dynamic_cast<SingleStringValue *>(value);
+		std::cout << "single: value=" << ptr->get_value() << std::endl;
+	} else if (key == "multi") {
+		MultiStringValue *ptr = dynamic_cast<MultiStringValue *>(value);
+		std::cout << "multi: value1=" << ptr->get_value1() << std::endl;
+		std::cout << "       value2=" << ptr->get_value2() << std::endl;
+	} else {
+		NumValue *ptr = dynamic_cast<NumValue *>(value);
+		std::cout << "num: value=" << ptr->get_value() << std::endl;
+
+	}
+}
+
+int main() {
+	std::map<std::string, MapValueBase> test_map;
+	std::map<std::string, MapValueBase>::iterator itr;
+
+	test_map["single"] = SingleStringValue("test_single");
+	test_map["multi"] = MultiStringValue("test_multi1", "test_multi2");
+	test_map["num"] = NumValue(42);
+
+	for (itr = test_map.begin(); itr != test_map.end(); ++itr) {
+		print_value(itr->first, &itr->second);
+	}
+}

--- a/srcs/Client/Client.cpp
+++ b/srcs/Client/Client.cpp
@@ -1,0 +1,108 @@
+#include <arpa/inet.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <sys/socket.h>
+#include <unistd.h>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+#include <stdexcept>
+#include "webserv.hpp"
+#include "Color.hpp"
+#include "Client.hpp"
+#include "Debug.hpp"
+
+namespace {
+	const int ERROR = -1;
+
+	int create_connect_socket() {
+		int connect_fd;
+		errno = 0;
+		connect_fd = socket(AF_INET, SOCK_STREAM, 0);
+		if (connect_fd == ERROR) {
+			std::string err_str = "[Client Error] socket: " + std::string(strerror(errno));
+			throw std::runtime_error(RED + err_str + RESET);
+		}
+		return connect_fd;
+	}
+
+	struct sockaddr_in create_connect_addr(const char *server_ip,
+										   const char *server_port) {
+		struct sockaddr_in	addr = {};
+		const int 			DECIMAL_BASE = 10;
+
+		addr.sin_family = AF_INET;
+		addr.sin_port = htons(std::strtol(server_port, NULL, DECIMAL_BASE));
+		addr.sin_addr.s_addr = inet_addr(server_ip);
+		return addr;
+	}
+
+	void connect_to_server(int connect_fd, struct sockaddr_in addr) {
+		socklen_t len = sizeof(addr);
+
+		errno = 0;
+		if (connect(connect_fd, (struct sockaddr *)&addr, len) == ERROR) {
+			std::string err_str = "[Client Error] connect: " + std::string(strerror(errno));
+			throw std::runtime_error(RED + err_str + RESET);
+		}
+	}
+
+	void send_to_server(int connect_fd, const std::string &send_msg) {
+		ssize_t	send_size;
+		size_t	msg_len = send_msg.size() + 1;
+		const char *msg = send_msg.c_str();
+
+		errno = 0;
+		send_size = send(connect_fd, msg, msg_len, MSG_DONTWAIT);
+		if (send_size == ERROR) {
+			std::string err_str = "[Client Error] send: " + std::string(strerror(errno));
+			throw std::runtime_error(RED + err_str + RESET);
+		}
+	}
+
+	std::string recv_message_from_server(int connect_fd) {
+		ssize_t		recv_size;
+		char		buf[BUFSIZ + 1];
+		std::string	recv_msg;
+
+		while (true) {
+			errno = 0;
+			recv_size = recv(connect_fd, buf, BUFSIZ, 0);
+			if (recv_size == ERROR) {
+				std::string err_str = "[Client Error] recv: " + std::string(strerror(errno));
+				throw std::runtime_error(RED + err_str + RESET);
+			}
+			buf[recv_size] = '\0';
+			recv_msg += buf;
+			if (recv_size < BUFSIZ) {
+				break;
+			}
+		}
+		// std::cout << "recv_size:" << recv_size << std::endl;
+		return recv_msg;
+	}
+}  // namespace
+
+Client::Client(const char *server_ip, const char *server_port) {
+	this->_connect_fd = create_connect_socket();
+	this->_addr = create_connect_addr(server_ip, server_port);
+}
+
+Client::~Client() {
+	if (_connect_fd != ERROR) {
+		errno = 0;
+		if (close(_connect_fd) == ERROR) {
+			std::cerr << RED "[Client Error] close: " << strerror(errno) << RESET << std::endl;
+		}
+		_connect_fd = ERROR;
+	}
+}
+
+void Client::process_server_connect(const std::string &send_msg) {
+	connect_to_server(this->_connect_fd, this->_addr);
+	send_to_server(this->_connect_fd, send_msg);
+	this->_recv_message = recv_message_from_server(this->_connect_fd);
+}
+
+std::string Client::get_recv_message() const { return this->_recv_message; }

--- a/srcs/Client/Client.hpp
+++ b/srcs/Client/Client.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <arpa/inet.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <string>
+#include "webserv.hpp"
+
+class Client {
+ public:
+	Client(const char *server_ip, const char *server_port);
+	~Client();
+
+	std::string get_recv_message() const;
+	void process_server_connect(const std::string &send_msg);
+
+ private:
+	int _connect_fd;
+	std::string _recv_message;
+	struct sockaddr_in _addr;
+};

--- a/srcs/Client/client_main.cpp
+++ b/srcs/Client/client_main.cpp
@@ -1,0 +1,37 @@
+#include <fstream>
+#include <iostream>
+#include "Client.hpp"
+#include "Color.hpp"
+
+namespace {
+	std::string RESPONSE_MSG = "GET / HTTP/1.1\r\n"
+							   "Host: 127.0.0.1\r\n"
+							   "\r\n";
+	std::string SERVER_IP = "127.0.0.1";
+	std::string SERVER_PORT = "8080";
+}  // namespace
+
+int main() {
+	try {
+		std::cout << "Request message:[" << std::endl;
+		std::cout << YELLOW << RESPONSE_MSG << RESET "\n]" << std::endl;
+
+		Client client = Client("127.0.0.1", "8080");
+		client.process_server_connect(RESPONSE_MSG);
+
+		std::string response_msg = client.get_recv_message();
+		std::cout << "Response message:[" << std::endl;
+		std::cout << CYAN << response_msg << RESET "\n]" << std::endl;
+
+		std::ofstream file("client_response.txt");
+		if (file.is_open()) {
+			file << response_msg;
+			file.close();
+		}
+		// std::fflush(stdout);
+	} catch (const std::exception &e) {
+		std::cerr << e.what() << std::endl;
+		return EXIT_FAILURE;
+	}
+	return EXIT_SUCCESS;
+}

--- a/srcs/IOMultiplexer/IOMultiplexer.cpp
+++ b/srcs/IOMultiplexer/IOMultiplexer.cpp
@@ -1,0 +1,376 @@
+#include <unistd.h>
+#include <algorithm>
+#include <cerrno>
+#include <cstring>
+#include <climits>
+#include <string>
+#include <vector>
+#include "webserv.hpp"
+#include "Color.hpp"
+#include "Debug.hpp"
+#include "Error.hpp"
+#include "IOMultiplexer.hpp"
+#include "Result.hpp"
+#include "Server.hpp"
+
+#if defined(__linux__) && !defined(USE_SELECT_MULTIPLEXER)
+
+namespace {
+	int INIT_SIZE = 1;
+	int EPOLL_TIMEOUT = 0;
+	int TIMEOUT = -1;
+	int TIMEOUT_MS = 2500;
+	int INIT_FD = -1;
+
+	int ERROR = -1;
+	int OK = 0;
+}
+
+EPollMultiplexer::EPollMultiplexer(int socket_fd) : _socket_fd(socket_fd),
+													_epoll_fd(INIT_FD),
+													_ev(),
+													_new_event() {
+	errno = 0;
+	this->_epoll_fd = epoll_create(INIT_SIZE);
+	if (this->_epoll_fd == ERROR) {
+		std::string err_info = create_error_info(errno, __FILE__, __LINE__);
+		throw std::runtime_error("[Server Error] epoll_create:" + err_info);
+	}
+
+	this->_ev.data.fd = this->_socket_fd;
+	this->_ev.events = EPOLLIN;
+	errno = 0;
+	if (epoll_ctl(this->_epoll_fd, EPOLL_CTL_ADD, this->_socket_fd, &this->_ev) == -1) {
+		std::string err_info = create_error_info(errno, __FILE__, __LINE__);
+		throw std::runtime_error("[Server Error] epoll_ctl:" + err_info);
+	}
+}
+
+EPollMultiplexer::~EPollMultiplexer() {
+	errno = 0;
+	if (close(this->_epoll_fd) == ERROR) {
+		std::string err_info = create_error_info(errno, __FILE__, __LINE__);
+		std::cerr << "[Server Error] close:" << err_info << std::endl;
+	}
+	this->_epoll_fd = INIT_FD;
+}
+
+Result<int, std::string> EPollMultiplexer::get_io_ready_fd() {
+	int ready_fd_count;
+
+	errno = 0;
+	ready_fd_count = epoll_wait(this->_epoll_fd, &this->_new_event, 1, TIMEOUT_MS);
+	if (ready_fd_count == -1) {
+		std::string err_info = create_error_info(errno, __FILE__, __LINE__);
+		return Result<int, std::string>::err("[Server Error] epoll_wait:" + err_info);
+	}
+	if (this->_new_event.events & EPOLLERR) {
+		std::string err_info = create_error_info("I/O Error occurred", __FILE__, __LINE__);
+		return Result<int, std::string>::err("[Server Error] epoll_wait:" + err_info);
+	}
+	if (ready_fd_count == EPOLL_TIMEOUT) {
+		return Result<int, std::string>::ok(TIMEOUT);
+	}
+	return Result<int, std::string>::ok(this->_new_event.data.fd);
+}
+
+Result<int, std::string> EPollMultiplexer::register_connect_fd(int connect_fd) {
+	this->_ev.events = EPOLLIN;
+	this->_ev.data.fd = connect_fd;
+	errno = 0;
+	if (epoll_ctl(this->_epoll_fd, EPOLL_CTL_ADD, connect_fd, &this->_ev) == ERROR) {
+		std::string err_info = create_error_info(errno, __FILE__, __LINE__);
+		return Result<int, std::string>::err("[Server Error] epoll_ctl:" + err_info);
+	}
+	return Result<int, std::string>::ok(OK);
+}
+
+Result<int, std::string> EPollMultiplexer::clear_fd(int clear_fd) {
+	errno = 0;
+	if (epoll_ctl(this->_epoll_fd, EPOLL_CTL_DEL, clear_fd, NULL) == ERROR) {
+		std::string err_info = create_error_info(errno, __FILE__, __LINE__);
+		return Result<int, std::string>::err("[Server Error] epoll_ctl:" + err_info);
+	}
+	return Result<int, std::string>::ok(OK);
+}
+
+#elif defined(__APPLE__) && !defined(USE_SELECT_MULTIPLEXER)
+
+namespace {
+	const int KEVENT_TIMEOUT = 0;
+	const int INIT_KQ = -1;
+	const int EVENT_COUNT = 1;
+	const int TIMEOUT = -1;
+
+	const int ERROR = -1;
+	const int OK = 0;
+
+	Result<int, std::string> init_kqueue() {
+		int kq;
+
+		errno = 0;
+		kq = kqueue();
+		if (kq == ERROR) {
+			return Result<int, std::string>::err(strerror(errno));
+		}
+		return Result<int, std::string>::ok(kq);
+	}
+
+	Result<int, std::string> kevent_register(int kq, struct kevent *change_event) {
+		errno = 0;
+		if (kevent(kq, change_event, EVENT_COUNT, NULL, 0, NULL) == ERROR) {
+			return Result<int, std::string>::err(strerror(errno));
+		}
+		return Result<int, std::string>::ok(OK);
+	}
+
+	Result<int, std::string> kevent_wait(int kq, struct kevent *new_event) {
+		int events;
+		struct timespec	timeout = {};
+
+		timeout.tv_sec = 2;
+		timeout.tv_nsec = 500 * 1000;
+
+		errno = 0;
+		events = kevent(kq, NULL, 0, new_event, EVENT_COUNT, &timeout);
+		if (events == ERROR) {
+			return Result<int, std::string>::err(strerror(errno));
+		}
+		return Result<int, std::string>::ok(events);
+	}
+
+	Result<int, std::string> cast_fd_uintptr_to_int(uintptr_t ident) {
+		if (ident > static_cast<uintptr_t>(INT_MAX)) {
+			return Result<int, std::string>::err("invalid fd");
+		}
+		return Result<int, std::string>::ok(static_cast<int>(ident));
+	}
+}  // namespace
+
+KqueueMultiplexer::KqueueMultiplexer(int socket_fd) : _socket_fd(socket_fd),
+													  _kq(INIT_KQ),
+													  _change_event(),
+													  _new_event() {
+	Result<int, std::string> kq_result, kevent_result;
+
+	DEBUG_SERVER_PRINT("[I/O multiplexer : kqueue]");
+
+	kq_result = init_kqueue();
+	if (kq_result.is_err()) {
+		std::string err_info = create_error_info(kq_result.get_err_value(), __FILE__, __LINE__);
+		throw std::runtime_error("[Server Error] kqueue:" + err_info);
+	}
+	this->_kq = kq_result.get_ok_value();
+
+	EV_SET(&this->_change_event, this->_socket_fd, EVFILT_READ, EV_ADD, 0, 0, NULL);
+	kevent_result = kevent_register(this->_kq, &this->_change_event);
+	if (kevent_result.is_err()) {
+		std::string err_info = create_error_info(kevent_result.get_err_value(), __FILE__, __LINE__);
+		throw std::runtime_error("[Server Error] kevent:" + err_info);
+	}
+}
+
+KqueueMultiplexer::~KqueueMultiplexer() {
+	// todo: clear all event?
+}
+
+Result<int, std::string> KqueueMultiplexer::get_io_ready_fd() {
+	Result<int, std::string> kevent_result, cast_result;
+	int new_events;
+
+	kevent_result = kevent_wait(this->_kq, &this->_new_event);
+	if (kevent_result.is_err()) {
+		std::string err_info = create_error_info(kevent_result.get_err_value(), __FILE__, __LINE__);
+		return Result<int, std::string>::err("[Server Error] kevent:" + err_info);
+	}
+	new_events = kevent_result.get_ok_value();
+	if (new_events == KEVENT_TIMEOUT) {
+		return Result<int, std::string>::ok(TIMEOUT);
+	}
+
+	cast_result = cast_fd_uintptr_to_int(this->_new_event.ident);
+	if (cast_result.is_err()) {
+		std::string err_info = create_error_info(cast_result.get_err_value(), __FILE__, __LINE__);
+		return Result<int, std::string>::err("[Server Error]" + err_info);
+	}
+	return Result<int, std::string>::ok(cast_result.get_ok_value());
+}
+
+Result<int, std::string> KqueueMultiplexer::register_connect_fd(int connect_fd) {
+	EV_SET(&this->_change_event, connect_fd, EVFILT_READ, EV_ADD, 0, 0, NULL);
+	return kevent_register(this->_kq, &this->_change_event);
+}
+
+Result<int, std::string> KqueueMultiplexer::clear_fd(int clear_fd) {
+	Result<int, std::string> kevent_result;
+	std::string err_str, err_info;
+
+	EV_SET(&this->_change_event, clear_fd, EVFILT_READ, EV_DELETE, 0, 0, NULL);
+	kevent_result = kevent_register(this->_kq, &this->_change_event);
+	if (kevent_result.is_err()) {
+		err_info = create_error_info(kevent_result.get_err_value(), __FILE__, __LINE__);
+		err_str = "kevent:" + err_info;
+	}
+	errno = 0;
+	if (close(clear_fd) == ERROR) {
+		if (!err_str.empty()) {
+			err_str += " ,";
+		}
+		err_info = create_error_info(errno, __FILE__, __LINE__);
+		err_str += "close:" + err_info;
+	}
+	if (!err_str.empty()) {
+		return Result<int, std::string>::err(err_str);
+	}
+	return Result<int, std::string>::ok(OK);
+}
+
+#else
+
+namespace {
+	const int INIT_FD = -1;
+	const int MAX_SESSION = 128;
+	const int SELECT_TIMEOUT = 0;
+	const int TIMEOUT = -1;
+
+	int OK = 0;
+	int ERROR = -1;
+
+	fd_set init_fds(int socket_fd, const std::vector<int> &connect_fds) {
+		fd_set fds;
+		std::vector<int>::const_iterator fd;
+
+		FD_ZERO(&fds);
+		FD_SET(socket_fd, &fds);
+
+		for (fd = connect_fds.begin(); fd != connect_fds.end(); ++fd) {
+			if (*fd == INIT_FD) {
+				continue;
+			}
+			FD_SET(*fd, &fds);
+		}
+		return fds;
+	}
+
+	int get_max_fd(const std::vector<int> &connect_fds, int socket_fd) {
+		int max_fd;
+
+		max_fd = *std::max_element(connect_fds.begin(), connect_fds.end());
+		return std::max(max_fd, socket_fd);
+	}
+
+	Result<int, std::string> select_fds(int max_fd, fd_set *fds) {
+		struct timeval timeout = {};
+		int select_ret;
+
+		// timeout < 1.5sec, communicate error ??
+		timeout.tv_sec = 2;
+		timeout.tv_usec = 500 * 1000;  // 500ms
+
+		errno = 0;
+		select_ret = select(max_fd + 1, fds, NULL, NULL, &timeout);
+		if (select_ret == ERROR) {
+			return Result<int, std::string>::err(strerror(errno));
+		}
+		return Result<int, std::string>::ok(select_ret);
+	}
+
+	Result<int, int> get_ready_fd(const std::vector<int> &connect_fds,
+								  fd_set *fds, int socket_fd) {
+		std::vector<int>::const_iterator fd;
+
+		if (FD_ISSET(socket_fd, fds)) {
+			return Result<int, int>::ok(socket_fd);
+		}
+
+		for (fd = connect_fds.begin(); fd != connect_fds.end(); ++fd) {
+			if (*fd == INIT_FD) {
+				continue;
+			}
+			if (!FD_ISSET(*fd, fds)) {
+				continue;
+			}
+			return Result<int, int>::ok(*fd);
+		}
+		return Result<int, int>::err(ERROR);
+	}
+}  // namespace
+
+SelectMultiplexer::SelectMultiplexer(int socket_fd) {
+	DEBUG_SERVER_PRINT("[I/O multiplexer : select]");
+
+	this->_socket_fd = socket_fd;
+	this->_connect_fds = std::vector<int>(MAX_SESSION, INIT_FD);
+	this->_fds = init_fds(this->_socket_fd, this->_connect_fds);
+}
+
+SelectMultiplexer::~SelectMultiplexer() {
+	for (int i = 0; i < MAX_SESSION; ++i) {
+		if (this->_connect_fds[i] == INIT_FD) {
+			continue;
+		}
+		errno = 0;
+		if (close(this->_connect_fds[i]) == ERROR) {
+			std::string err_info = create_error_info(errno, __FILE__, __LINE__);
+			std::cerr << "[Error] close:" << err_info << std::endl;
+		}
+		this->_connect_fds[i] = INIT_FD;
+	}
+}
+
+Result<int, std::string> SelectMultiplexer::get_io_ready_fd() {
+	int max_fd;
+	Result<int, std::string> select_result;
+	Result<int, int> fd_result;
+
+	this->_fds = init_fds(this->_socket_fd, this->_connect_fds);
+	max_fd = get_max_fd(this->_connect_fds, this->_socket_fd);
+	select_result = select_fds(max_fd, &this->_fds);
+	if (select_result.is_err()) {
+		std::string err_info = create_error_info(select_result.get_err_value(), __FILE__, __LINE__);
+		return Result<int, std::string>::err("[Server Error] select:" + err_info);
+	}
+	if (select_result.get_ok_value() == SELECT_TIMEOUT) {
+		return Result<int, std::string>::ok(TIMEOUT);
+	}
+
+	fd_result = get_ready_fd(this->_connect_fds, &this->_fds, this->_socket_fd);
+	if (fd_result.is_err()) {
+		std::string err_info = create_error_info("ready fd not found", __FILE__, __LINE__);
+		return Result<int, std::string>::err("[Server Error] " + err_info);
+	}
+	return Result<int, std::string>::ok(fd_result.get_ok_value());
+}
+
+Result<int, std::string> SelectMultiplexer::clear_fd(int clear_fd) {
+	std::vector<int>::iterator fd = std::find(this->_connect_fds.begin(),
+											  this->_connect_fds.end(),
+											  clear_fd);
+	if (fd == this->_connect_fds.end()) {
+		std::string err_info = create_error_info("clear fd not found", __FILE__, __LINE__);
+		return Result<int, std::string>::err("[Server Error] " + err_info);
+	}
+
+	FD_CLR(*fd, &this->_fds);
+	errno = 0;
+	if (close(*fd) == ERROR) {
+		std::string err_info = create_error_info(errno, __FILE__, __LINE__);
+		return Result<int, std::string>::err("close:" + err_info);
+	}
+	*fd = INIT_FD;
+	return Result<int, std::string>::ok(OK);
+}
+
+Result<int, std::string> SelectMultiplexer::register_connect_fd(int connect_fd) {
+	std::vector<int>::iterator fd = std::find(this->_connect_fds.begin(),
+											  this->_connect_fds.end(),
+											  INIT_FD);
+	if (fd == this->_connect_fds.end()) {
+		std::string err_info = create_error_info("over max connection", __FILE__, __LINE__);
+		return Result<int, std::string>::err("[Server Info] " + err_info);
+	}
+	*fd = connect_fd;
+	return Result<int, std::string>::ok(OK);
+}
+
+#endif

--- a/srcs/IOMultiplexer/IOMultiplexer.hpp
+++ b/srcs/IOMultiplexer/IOMultiplexer.hpp
@@ -1,0 +1,76 @@
+#pragma once
+
+# include <iostream>
+# include <string>
+# include <vector>
+# include "Result.hpp"
+
+# if defined(__linux__) && !defined(USE_SELECT_MULTIPLEXER)
+#  include <sys/epoll.h>
+# elif defined(__APPLE__) && !defined(USE_SELECT_MULTIPLEXER)
+#  include <sys/event.h>
+#  include <sys/time.h>
+# else
+#  include <sys/select.h>
+# endif
+
+class IOMultiplexer {
+ public:
+	virtual ~IOMultiplexer() {}
+	virtual Result<int, std::string> get_io_ready_fd() = 0;
+	virtual Result<int, std::string> register_connect_fd(int connect_fd) = 0;
+	virtual Result<int, std::string> clear_fd(int clear_fd) = 0;
+};
+
+#if defined(__linux__) && !defined(USE_SELECT_MULTIPLEXER)
+
+class EPollMultiplexer : public IOMultiplexer {
+ public:
+	explicit EPollMultiplexer(int socket_fd);
+	virtual ~EPollMultiplexer();
+	virtual Result<int, std::string> get_io_ready_fd();
+	virtual Result<int, std::string> register_connect_fd(int connect_fd);
+	virtual Result<int, std::string> clear_fd(int clear_fd);
+ private:
+	int _socket_fd;
+	int _epoll_fd;
+	struct epoll_event _ev;
+	struct epoll_event _new_event;
+};
+
+#elif defined(__APPLE__) && !defined(USE_SELECT_MULTIPLEXER)
+
+class KqueueMultiplexer : public IOMultiplexer {
+ public:
+	explicit KqueueMultiplexer(int socket_fd);
+	virtual ~KqueueMultiplexer();
+	virtual Result<int, std::string> get_io_ready_fd();
+	virtual Result<int, std::string> register_connect_fd(int connect_fd);
+	virtual Result<int, std::string> clear_fd(int clear_fd);
+
+ private:
+	int _socket_fd;
+	int _kq;
+	struct kevent _change_event;
+	struct kevent _new_event;
+};
+
+#else
+
+class SelectMultiplexer : public IOMultiplexer {
+ public:
+	explicit SelectMultiplexer(int socket_fd);
+	virtual ~SelectMultiplexer();
+	virtual Result<int, std::string> get_io_ready_fd();
+	virtual Result<int, std::string> register_connect_fd(int connect_fd);
+	virtual Result<int, std::string> clear_fd(int clear_fd);
+
+ private:
+	int _socket_fd;
+	std::vector<int> _connect_fds;
+	// std::vector<int> _ready_fds;
+	// std::vector<int> _active_fds;
+	fd_set _fds;
+};
+
+#endif

--- a/srcs/Server/Server.cpp
+++ b/srcs/Server/Server.cpp
@@ -1,0 +1,239 @@
+#include <errno.h>
+#include <netdb.h>
+#include <signal.h>
+#include <sys/socket.h>
+#include <unistd.h>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+#include "webserv.hpp"
+#include "Color.hpp"
+#include "Debug.hpp"
+#include "Error.hpp"
+#include "IOMultiplexer.hpp"
+#include "Result.hpp"
+#include "Server.hpp"
+
+namespace {
+	const int OK = 0;
+
+	const int ACCEPT_ERROR = -1;
+	const int CLOSE_ERROR = -1;
+	const int RECV_ERROR = -1;
+	const int SEND_ERROR = -1;
+
+	const int FLAG_NONE = 0;
+	const int TIMEOUT = -1;
+
+	Result<int, std::string> accept_connection(int socket_fd) {
+		int connect_fd;
+
+		errno = 0;
+		connect_fd = accept(socket_fd, NULL, NULL);  // NULL:peer addr not needed
+		if (connect_fd == ACCEPT_ERROR) {
+			return Result<int, std::string>::err(strerror(errno));
+		}
+		return Result<int, std::string>::ok(connect_fd);
+	}
+
+	Result<std::string, std::string> recv_request(int connect_fd) {
+		char		buf[BUFSIZ + 1];
+		ssize_t		recv_size;
+		std::string	recv_msg;
+
+		while (true) {
+			errno = 0;
+			recv_size = recv(connect_fd, buf, BUFSIZ, FLAG_NONE);
+			// todo: flg=MSG_DONTWAIT, errno=EAGAIN -> continue?
+			if (recv_size == RECV_ERROR || recv_size > BUFSIZ) {
+				return Result<std::string, std::string>::err(strerror(errno));
+			}
+			buf[recv_size] = '\0';
+			recv_msg += buf;
+			if (recv_size < BUFSIZ) {
+				break;
+			}
+		}
+		return Result<std::string, std::string>::ok(recv_msg);
+	}
+
+	Result<int, std::string> send_response(int connect_fd, const HttpResponse &response) {
+		char	*response_message = response.get_response_message();
+		size_t	message_len = response.get_response_size();
+
+		errno = 0;
+		if (send(connect_fd, response_message, message_len, MSG_DONTWAIT) == SEND_ERROR) {
+			return Result<int, std::string>::err(strerror(errno));
+		}
+		return Result<int, std::string>::ok(OK);
+	}
+
+	void stop_by_signal(int sig) {
+		DEBUG_SERVER_PRINT("stop by signal %d", sig);
+		std::cerr << "[Server] Stop running by signal" << std::endl;
+		std::exit(0);
+	}
+
+	Result<int, std::string> set_signal() {
+		std::string err_info;
+
+		errno = 0;
+		if (signal(SIGABRT, stop_by_signal) == SIG_ERR) {
+			err_info = create_error_info(errno, __FILE__, __LINE__);
+			return Result<int, std::string>::err(err_info);
+		}
+		if (signal(SIGINT, stop_by_signal) == SIG_ERR) {
+			err_info = create_error_info(errno, __FILE__, __LINE__);
+			return Result<int, std::string>::err(err_info);
+		}
+		if (signal(SIGTERM, stop_by_signal) == SIG_ERR) {
+			err_info = create_error_info(errno, __FILE__, __LINE__);
+			return Result<int, std::string>::err(err_info);
+		}
+		if (signal(SIGPIPE, SIG_IGN) == SIG_ERR) {
+			err_info = create_error_info(errno, __FILE__, __LINE__);
+			return Result<int, std::string>::err(err_info);
+		}
+		if (signal(SIGCHLD, SIG_IGN) == SIG_ERR) {
+			err_info = create_error_info(errno, __FILE__, __LINE__);
+			return Result<int, std::string>::err(err_info);
+		}
+		return Result<int, std::string>::ok(OK);
+	}
+
+	Result<IOMultiplexer *, std::string> create_io_multiplexer_fds(int socket_fd) {
+		IOMultiplexer *fds;
+
+		try {
+#if defined(__linux__) && !defined(USE_SELECT_MULTIPLEXER)
+			fds = new EPollMultiplexer(socket_fd);
+#elif defined(__APPLE__) && !defined(USE_SELECT_MULTIPLEXER)
+			fds = new KqueueMultiplexer(socket_fd);
+#else
+			fds = new SelectMultiplexer(socket_fd);
+#endif
+		} catch (std::bad_alloc const &e) {
+			std::string err_info = create_error_info("Failed to allocate memory", __FILE__, __LINE__);
+			return Result<IOMultiplexer *, std::string>::err(err_info);
+		}
+		return Result<IOMultiplexer *, std::string>::ok(fds);
+	}
+}  // namespace
+
+Server::Server(const char *server_ip,
+			   const char *server_port) : _socket(server_ip, server_port),
+			   							  _recv_message(),
+										  _fds(NULL) {
+	Result<int, std::string> socket_result, signal_result;
+	Result<IOMultiplexer *, std::string> fds_result;
+
+	socket_result = this->_socket.get_socket_result();
+	if (socket_result.is_err()) {
+		std::string socket_err_msg = socket_result.get_err_value();
+		throw std::runtime_error(RED "[Server Error] Initialization error: " + socket_err_msg + RESET);
+	}
+
+	signal_result = set_signal();
+	if (signal_result.is_err()) {
+		throw std::runtime_error(RED "[Server Error] Initialization error: signal: " + signal_result.get_err_value() + RESET);
+	}
+
+	fds_result = create_io_multiplexer_fds(this->_socket.get_socket_fd());
+	if (fds_result.is_err()) {
+		throw std::runtime_error(RED "[Server Error] Initialization error: " + fds_result.get_err_value() + RESET);
+	}
+	this->_fds = fds_result.get_ok_value();
+}
+
+Server::~Server() { delete this->_fds; }
+
+void Server::process_client_connection() {
+	Result<int, std::string> fd_ready_result;
+	int ready_fd;
+
+	while (true) {
+		fd_ready_result = this->_fds->get_io_ready_fd();
+		if (fd_ready_result.is_err()) {
+			throw std::runtime_error(RED + fd_ready_result.get_err_value() + RESET);
+		}
+		if (fd_ready_result.get_ok_value() == TIMEOUT) {
+			std::cerr << "[Server INFO] timeout" << std::endl;
+			break;
+		}
+
+		ready_fd = fd_ready_result.get_ok_value();
+		fd_ready_result = communicate_with_client(ready_fd);
+		if (fd_ready_result.is_err()) {
+			throw std::runtime_error(RED + fd_ready_result.get_err_value() + RESET);
+		}
+	}
+}
+
+Result<int, std::string> Server::communicate_with_client(int ready_fd) {
+	if (ready_fd == this->_socket.get_socket_fd()) {
+		return accept_and_store_connect_fd();
+	} else {
+		return communicate_with_ready_client(ready_fd);
+	}
+}
+
+Result<int, std::string> Server::accept_and_store_connect_fd() {
+	int connect_fd;
+	std::string err_info;
+	Result<int, std::string> accept_result, fd_store_result;
+
+	accept_result = accept_connection(this->_socket.get_socket_fd());
+	if (accept_result.is_err()) {
+		err_info = create_error_info(accept_result.get_err_value(), __FILE__, __LINE__);
+		return Result<int, std::string>::err("[Server Error] accept: " + err_info);
+	}
+	connect_fd = accept_result.get_ok_value();
+
+	fd_store_result = this->_fds->register_connect_fd(connect_fd);
+	if (fd_store_result.is_err()) {
+		err_info = create_error_info(fd_store_result.get_err_value(), __FILE__, __LINE__);
+		std::cerr << "[Server Error]" << err_info << std::endl;
+		errno = 0;
+		if (close(connect_fd) == CLOSE_ERROR) {
+			err_info = create_error_info(errno, __FILE__, __LINE__);
+			std::cerr << "[Server Error] close: "<< err_info << std::endl;
+		}
+	}
+	return Result<int, std::string>::ok(OK);
+}
+
+Result<int, std::string> Server::communicate_with_ready_client(int ready_fd) {
+	Result<std::string, std::string>recv_result;
+	Result<int, std::string> send_result, clear_result;
+	std::string err_info;
+
+	recv_result = recv_request(ready_fd);
+	if (recv_result.is_err()) {
+		err_info = create_error_info(recv_result.get_err_value(), __FILE__, __LINE__);
+		return Result<int, std::string>::err("[Server Error] recv: " + err_info);
+	}
+	this->_recv_message = recv_result.get_ok_value();
+	DEBUG_SERVER_PRINT("connected. recv:[%s]", this->_recv_message.c_str());
+
+	// request, response
+	HttpRequest request = HttpRequest(this->_recv_message);
+	HttpResponse response = HttpResponse(request);
+
+	// send
+	send_result = send_response(ready_fd, response);
+	if (send_result.is_err()) {
+		// printf(BLUE "   server send error\n" RESET);
+		err_info = create_error_info(send_result.get_err_value(), __FILE__, __LINE__);
+		return Result<int, std::string>::err("[Server Error] send: " + err_info);
+	}
+
+	clear_result = this->_fds->clear_fd(ready_fd);
+	if (clear_result.is_err()) {
+		err_info = create_error_info(clear_result.get_err_value(), __FILE__, __LINE__);
+		std::cerr << "[Server Error] clear_fd: " + err_info << std::endl;
+	}
+	return Result<int, std::string>::ok(OK);
+}
+
+std::string Server::get_recv_message() const { return this->_recv_message; }  // todo: for test, debug

--- a/srcs/Server/Server.hpp
+++ b/srcs/Server/Server.hpp
@@ -1,0 +1,45 @@
+#pragma once
+
+# include <string>
+# include <vector>
+# include "IOMultiplexer.hpp"
+# include "Result.hpp"
+# include "Socket.hpp"
+
+# define TEST_RESPONSE_MSG	"test response"
+
+// Mock -> gmock ??
+////////////////////////////////////////////////
+class HttpRequest {
+ public:
+	explicit HttpRequest(const std::string &msg) { (void)msg; }
+};
+
+class HttpResponse {
+ public:
+	explicit HttpResponse(HttpRequest request) { (void)request; }
+	char *get_response_message() const { return const_cast<char *>(TEST_RESPONSE_MSG); }
+	size_t get_response_size() const {
+		return std::string(TEST_RESPONSE_MSG).size();
+	}
+};
+////////////////////////////////////////////////
+
+class Server {
+ public:
+	Server(const char *server_ip, const char *server_port);  // tmp
+	// Server(const Config config);  // todo
+	~Server();
+
+	void process_client_connection();
+	std::string get_recv_message() const;  // todo: for test, debug
+
+ private:
+	Socket _socket;
+	std::string _recv_message;  // for test. this variable valid only connect with 1 client
+	IOMultiplexer *_fds;
+
+	Result<int, std::string> communicate_with_client(int ready_fd);
+	Result<int, std::string> accept_and_store_connect_fd();
+	Result<int, std::string> communicate_with_ready_client(int ready_fd);
+};

--- a/srcs/main.cpp
+++ b/srcs/main.cpp
@@ -3,12 +3,16 @@
 #include <string>
 #include "webserv.hpp"
 #include "Debug.hpp"
+#include "Server.hpp"
 
 namespace {
 	int CONFIG_FILE_INDEX = 1;
 	int EXECUTABLE_FILE_ONLY_ARGC = 1;
 	int CONFIG_FILE_GIVEN_ARGC = 2;
 	std::string INVALID_ARGUMENT_ERROR_MSG = "[Error] invalid argument";
+
+	const char *SERVER_IP = "127.0.0.1";
+	const char *SERVER_PORT = "8080";
 
 	void validate_argc(int argc) {
 		if (argc == EXECUTABLE_FILE_ONLY_ARGC) {
@@ -24,18 +28,15 @@ namespace {
 int main(int argc, char **argv) {
 	std::string		config_file_path;
 	// Configuration	config;  // todo
-	// Server			server;  // todo
 
 	try {
 		validate_argc(argc);
 		config_file_path = get_valid_config_file_path(argv[CONFIG_FILE_INDEX]);
 		DEBUG_PRINT("config_file_path=[%s]", config_file_path.c_str());
 
-		// if path is 'default', config set to default
 		// config = Configuration(config_file_path);
-
-		// server = Server.start_up(config);  // load config and setup socket
-		// server.run();  // connect to client
+		Server server = Server(SERVER_IP, SERVER_PORT);  // load config and setup socket
+		server.process_client_connection();
 	}
 	catch (std::exception const &e) {
 		std::cerr << e.what() << std::endl;

--- a/test/unit_test/TestServer.cpp
+++ b/test/unit_test/TestServer.cpp
@@ -1,0 +1,376 @@
+#include <netdb.h>
+#include <pthread.h>
+#include <exception>
+#include <string>
+#include <vector>
+#include "gtest/gtest.h"
+#include "webserv.hpp"
+#include "Client.hpp"
+#include "Color.hpp"
+#include "Debug.hpp"
+#include "Server.hpp"
+
+namespace {
+	int OK = 0;
+	const char *SERVER_IP = "127.0.0.1";
+	const char *SERVER_PORT = "8080";
+
+	struct s_server {
+		const char	*server_ip;
+		const char	*server_port;
+		std::string	recv_msg;
+	};
+
+	struct s_client {
+		int			no;
+		const char	*server_ip;
+		const char	*server_port;
+		std::string	send_msg;
+		std::string	recv_msg;
+	};
+
+/* helper */
+	void *run_server(void *server_info) {
+		s_server	*s = (s_server *)server_info;
+		bool		is_server_success = true;
+
+		try {
+			DEBUG_SERVER_PRINT("start");
+			Server server = Server(s->server_ip, s->server_port);
+			DEBUG_SERVER_PRINT("connecting...");
+			server.process_client_connection();
+			s->recv_msg = server.get_recv_message();
+			// vvv this func can print only 1 message vv
+			// printf("server connected. recv:[%s]\n", s->recv_msg.c_str());
+		}
+		catch (std::exception const &e) {
+			is_server_success = false;
+			std::cerr << e.what() << std::endl;
+		}
+		return (void *)(is_server_success);
+	}
+
+	void *run_client(void *client_info) {
+		s_client	*c = (s_client *)client_info;
+		bool		is_client_success = true;
+		std::string msg = c->send_msg;
+
+		if (c->no != 0) {
+			msg += std::to_string(c->no);
+		}
+
+		try {
+			DEBUG_CLIENT_PRINT("no:%d start", c->no);
+			Client client = Client(c->server_ip, c->server_port);
+			sleep(1);
+			DEBUG_CLIENT_PRINT("no:%d connecting...", c->no);
+			client.process_server_connect(msg);
+			c->recv_msg = client.get_recv_message();
+			DEBUG_CLIENT_PRINT("no:%d connected. recv:[%s]", c->no, c->recv_msg.c_str());
+		}
+		catch (std::exception const &e) {
+			is_client_success = false;
+			std::cerr << e.what() << std::endl;
+		}
+		return (void *)(is_client_success);
+	}
+
+	void run_server_and_client(const char *server_ip,
+							   const char *server_port,
+							   const std::string &client_send_msg,
+							   std::string &server_recv_msg,
+							   std::string &client_recv_msg) {
+		s_server server_info = {server_ip, server_port, ""};
+		s_client client_info = {0, server_ip, server_port, client_send_msg, ""};
+		pthread_t server_tid, client_tid;
+		int ret_server, ret_client;
+		bool is_server_success, is_client_success;
+
+		ret_server = pthread_create(&server_tid, NULL, run_server, (void *)&server_info);
+		ret_client = pthread_create(&client_tid, NULL, run_client, (void *)&client_info);
+		if (ret_server != OK || ret_client != OK) {
+			throw std::runtime_error("pthread_create error");
+		}
+
+		ret_server = pthread_join(server_tid, (void **)&is_server_success);
+		ret_client = pthread_join(client_tid, (void **)&is_client_success);
+		if (ret_server != OK || ret_client != OK) {
+			throw std::runtime_error("pthread_join error");
+		}
+		if (!is_server_success) {
+			throw std::runtime_error("server error");
+		}
+		if (!is_client_success) {
+			throw std::runtime_error("client error");
+		}
+		server_recv_msg = server_info.recv_msg;
+		client_recv_msg = client_info.recv_msg;
+	}
+
+	std::vector<s_client> init_client_infos(int client_count,
+											const char *server_ip,
+											const char *server_port,
+											const std::string &client_send_msg) {
+		std::vector<s_client> client_infos(client_count, {0, server_ip, server_port, client_send_msg, ""});
+		for (int i = 0; i < client_count; ++i) {
+			client_infos[i].no = i;
+		}
+		return client_infos;
+	}
+
+	void run_server_and_multi_client(const char *server_ip,
+									 const char *server_port,
+									 const std::string &client_send_msg,
+									 std::string &server_recv_msg,
+									 std::vector<std::string> &client_recv_msgs,
+									 int client_count) {
+		s_server server_info = {server_ip, server_port, ""};
+		std::vector<s_client> client_infos = init_client_infos(client_count, server_ip, server_port, client_send_msg);
+		pthread_t server_tid;
+		std::vector<pthread_t> client_tids(client_count);
+		int ret_server, ret_client;
+		bool is_server_success, is_client_success;
+
+		ret_server = pthread_create(&server_tid, NULL, run_server, (void *)&server_info);
+		if (ret_server != OK) {
+			throw std::runtime_error("pthread_create error");
+		}
+		for (int i = 0; i < client_count; ++i) {
+			ret_client = pthread_create(&client_tids[i], NULL, run_client, (void *)&client_infos[i]);
+			if (ret_client != OK) {
+				throw std::runtime_error("pthread_create error");
+			}
+		}
+
+		ret_server = pthread_join(server_tid, (void **)&is_server_success);
+		if (ret_server != OK || !is_server_success) {
+			throw std::runtime_error("server error");
+		}
+		for (int i = 0; i < client_count; ++i) {
+			ret_client = pthread_join(client_tids[i], (void **)&is_client_success);
+			if (ret_client != OK || !is_client_success) {
+				throw std::runtime_error("client error");
+			}
+		}
+		server_recv_msg = server_info.recv_msg;
+		for (int i = 0; i < client_count; ++i) {
+			client_recv_msgs[i] = client_infos[i].recv_msg;
+		}
+	}
+}
+// int port = 49152;
+
+TEST(ServerUnitTest, Constructor) {
+	EXPECT_NO_THROW(Server(SERVER_IP, SERVER_PORT));
+}
+
+TEST(ServerUnitTest, ConstructorThrowException) {
+	EXPECT_ANY_THROW(Server("hoge", SERVER_PORT));
+	EXPECT_ANY_THROW(Server("42", SERVER_PORT));
+	EXPECT_ANY_THROW(Server("127.0.0.256", SERVER_PORT));
+	EXPECT_ANY_THROW(Server(SERVER_IP, "a"));
+	EXPECT_ANY_THROW(Server(SERVER_IP, "-1"));
+	EXPECT_ANY_THROW(Server("huga", "-1"));
+}
+
+TEST(ServerUnitTest, ConnectClientCase1) {
+	std::string msg = "test request";
+	std::string server_recv_msg;
+	std::string client_recv_msg;
+
+	try {
+		run_server_and_client(SERVER_IP,
+							  SERVER_PORT,
+							  msg,
+							  server_recv_msg,
+							  client_recv_msg);
+		// EXPECT_EQ(msg, server_recv_msg);
+		EXPECT_EQ("test response", client_recv_msg);
+		std::cerr << YELLOW " msg            :[" << msg << "]" RESET << std::endl;
+		std::cerr << YELLOW " server_recv_msg:[" << server_recv_msg << "]" RESET << std::endl;
+		std::cerr << YELLOW " client_recv_msg:[" << client_recv_msg << "]" RESET << std::endl;
+	}
+	catch (std::exception const &e) {
+		FAIL() << e.what() << std::endl;
+	}
+}
+
+TEST(ServerUnitTest, ConnectClientCase2) {
+	std::string msg = "";
+	std::string server_recv_msg;
+	std::string client_recv_msg;
+
+	try {
+		run_server_and_client(SERVER_IP,
+							  SERVER_PORT,
+							  msg,
+							  server_recv_msg,
+							  client_recv_msg);
+		EXPECT_EQ(msg, server_recv_msg);
+		EXPECT_EQ("test response", client_recv_msg);
+		std::cerr << YELLOW " msg            :[" << msg << "]" RESET << std::endl;
+		std::cerr << YELLOW " server_recv_msg:[" << server_recv_msg << "]" RESET << std::endl;
+		std::cerr << YELLOW " client_recv_msg:[" << client_recv_msg << "]" RESET << std::endl;
+	}
+	catch (std::exception const &e) {
+		FAIL() << e.what() << std::endl;
+	}
+}
+
+TEST(ServerUnitTest, ConnectClientCase3) {
+	std::string msg = "a\n\n\nb\n\n\n\n\r\nc\td";
+	std::string server_recv_msg;
+	std::string client_recv_msg;
+
+	try {
+		run_server_and_client(SERVER_IP,
+							  SERVER_PORT,
+							  msg,
+							  server_recv_msg,
+							  client_recv_msg);
+		EXPECT_EQ(msg, server_recv_msg);
+		EXPECT_EQ("test response", client_recv_msg);
+		std::cerr << YELLOW " msg            :[" << msg << "]" RESET << std::endl;
+		std::cerr << YELLOW " server_recv_msg:[" << server_recv_msg << "]" RESET << std::endl;
+		std::cerr << YELLOW " client_recv_msg:[" << client_recv_msg << "]" RESET << std::endl;
+	}
+	catch (std::exception const &e) {
+		FAIL() << e.what() << std::endl;
+	}
+}
+
+TEST(ServerUnitTest, ConnectClientCase4) {
+	std::string msg =
+			"GET /home.html HTTP/1.1\r\n"
+			"Host: developer.mozilla.org\r\n"
+			"User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10.9; rv:50.0) Gecko/20100101 Firefox/50.0\r\n"
+			"Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8\r\n"
+			"Accept-Language: en-US,en;q=0.5\r\n"
+			"Accept-Encoding: gzip, deflate, br\r\n"
+			"Referer: https://developer.mozilla.org/testpage.html\r\n"
+			"Connection: keep-alive\r\n"
+			"Upgrade-Insecure-Requests: 1\r\n"
+			"If-Modified-Since: Mon, 18 Jul 2016 02:36:04 GMT\r\n"
+			"If-None-Match: \"c561c68d0ba92bbeb8b0fff2a9199f722e3a621a\"\r\n"
+			"Cache-Control: max-age=0\r\n";
+	std::string server_recv_msg;
+	std::string client_recv_msg;
+
+	try {
+		run_server_and_client(SERVER_IP,
+							  SERVER_PORT,
+							  msg,
+							  server_recv_msg,
+							  client_recv_msg);
+		EXPECT_EQ(msg, server_recv_msg);
+		EXPECT_EQ("test response", client_recv_msg);
+		std::cerr << YELLOW " msg            :[" << msg << "]" RESET << std::endl;
+		std::cerr << YELLOW " server_recv_msg:[" << server_recv_msg << "]" RESET << std::endl;
+		std::cerr << YELLOW " client_recv_msg:[" << client_recv_msg << "]" RESET << std::endl;
+	}
+	catch (std::exception const &e) {
+		FAIL() << e.what() << std::endl;
+	}
+}
+
+TEST(ServerUnitTest, ConnectClientErrorInvalidIP) {
+	std::string msg = "test request";
+	std::string server_recv_msg;
+	std::string client_recv_msg;
+
+	EXPECT_ANY_THROW(run_server_and_client("hoge",
+										   SERVER_PORT,
+										   msg,
+										   server_recv_msg,
+										   client_recv_msg));
+}
+
+TEST(ServerUnitTest, ConnectClientErrorInvalidPort) {
+	std::string msg = "test request";
+	std::string server_recv_msg;
+	std::string client_recv_msg;
+
+	EXPECT_ANY_THROW(run_server_and_client(SERVER_IP,
+										   "-1",
+										   msg,
+										   server_recv_msg,
+										   client_recv_msg));
+}
+
+TEST(ServerUnitTest, ConnectMultiClient2) {
+	int client_count = 2;
+	std::string msg = "test request";
+	std::string server_recv_msg;
+	std::vector<std::string> client_recv_msgs(client_count);
+
+	try {
+		run_server_and_multi_client(SERVER_IP,
+									SERVER_PORT,
+									msg,
+									server_recv_msg,
+									client_recv_msgs,
+									client_count);
+		// EXPECT_EQ(msg, server_recv_msg);
+		std::cerr << YELLOW " msg            :[" << msg << "]" RESET << std::endl;
+		std::cerr << YELLOW " server_recv_msg:[" << server_recv_msg << "]" RESET << std::endl;
+		for (int i = 0; i < client_count; ++i) {
+			EXPECT_EQ("test response", client_recv_msgs[i]);
+			std::cerr << YELLOW " client_recv_msg(" << i << "):[" << client_recv_msgs[i] << "]" RESET << std::endl;
+		}
+	}
+	catch (std::exception const &e) {
+		FAIL() << e.what();
+	}
+}
+
+TEST(ServerUnitTest, ConnectMultiClient5) {
+	int client_count = 5;
+	std::string msg = "test request";
+	std::string server_recv_msg;
+	std::vector<std::string> client_recv_msgs(client_count);
+
+	try {
+		run_server_and_multi_client(SERVER_IP,
+									SERVER_PORT,
+									msg,
+									server_recv_msg,
+									client_recv_msgs,
+									client_count);
+		// EXPECT_EQ(msg, server_recv_msg);
+		std::cerr << YELLOW " msg            :[" << msg << "]" RESET << std::endl;
+		std::cerr << YELLOW " server_recv_msg:[" << server_recv_msg << "]" RESET << std::endl;
+		for (int i = 0; i < client_count; ++i) {
+			EXPECT_EQ("test response", client_recv_msgs[i]);
+			std::cerr << YELLOW " client_recv_msg(" << i << "):[" << client_recv_msgs[i] << "]" RESET << std::endl;
+		}
+	}
+	catch (std::exception const &e) {
+		FAIL() << e.what();
+	}
+}
+
+TEST(ServerUnitTest, ConnectMultiClient20) {
+	int client_count = 20;
+	std::string msg = "test request";
+	std::string server_recv_msg;
+	std::vector<std::string> client_recv_msgs(client_count);
+
+	try {
+		run_server_and_multi_client(SERVER_IP,
+									SERVER_PORT,
+									msg,
+									server_recv_msg,
+									client_recv_msgs,
+									client_count);
+		// EXPECT_EQ(msg, server_recv_msg);
+		std::cerr << YELLOW " msg            :[" << msg << "]" RESET << std::endl;
+		std::cerr << YELLOW " server_recv_msg:[" << server_recv_msg << "]" RESET << std::endl;
+		for (int i = 0; i < client_count; ++i) {
+			EXPECT_EQ("test response", client_recv_msgs[i]);
+			std::cerr << YELLOW " client_recv_msg(" << i << "):[" << client_recv_msgs[i] << "]" RESET << std::endl;
+		}
+	}
+	catch (std::exception const &e) {
+		FAIL() << e.what();
+	}
+}


### PR DESCRIPTION
## 実装内容

### Server
- e80ab7e
- [x] `socket()`を呼び出しsocketを作成 [Server.cpp L125](https://github.com/Webserve4242/webserv/pull/22/commits/e80ab7eac330a8efa3d8e17b7ca5164fbdca52de#diff-cc7b297cf0a88731c75c91292f140e78d982c7e144ba0b37aea24995af391907R125)
- [x] `select(), poll(), epoll()` 
  - コンパイルフラグ `-D`で使用する関数を管理している [Socket.cpp L109](https://github.com/Webserve4242/webserv/pull/22/commits/e80ab7eac330a8efa3d8e17b7ca5164fbdca52de#diff-cc7b297cf0a88731c75c91292f140e78d982c7e144ba0b37aea24995af391907R109-R115) 
  - [x] interface class IOMultiplexer（select, epoll, kqueueはIOMultiplexerを継承）[IOMultiplexer.hpp L17](https://github.com/Webserve4242/webserv/pull/22/commits/e80ab7eac330a8efa3d8e17b7ca5164fbdca52de#diff-a3ca3ebcaaf075ffd48fb238d179581117de5231d36b39776b31ce9cae99f461R17-R23) 
  - [x] select (Linux & macOS) [IOMultiplexer L60](https://github.com/Webserve4242/webserv/pull/22/commits/e80ab7eac330a8efa3d8e17b7ca5164fbdca52de#diff-a3ca3ebcaaf075ffd48fb238d179581117de5231d36b39776b31ce9cae99f461R60-R74)
  - [x] epoll (Linux) [IOMultiplexer L27](https://github.com/Webserve4242/webserv/pull/22/commits/e80ab7eac330a8efa3d8e17b7ca5164fbdca52de#diff-a3ca3ebcaaf075ffd48fb238d179581117de5231d36b39776b31ce9cae99f461R27-R39)
  - [x] kqueue (macOS) [IOMultiplexer L43](https://github.com/Webserve4242/webserv/pull/22/commits/e80ab7eac330a8efa3d8e17b7ca5164fbdca52de#diff-a3ca3ebcaaf075ffd48fb238d179581117de5231d36b39776b31ce9cae99f461R43-R56)
- [x] `accept()` [L166](https://github.com/Webserve4242/webserv/pull/22/commits/e80ab7eac330a8efa3d8e17b7ca5164fbdca52de#diff-cc7b297cf0a88731c75c91292f140e78d982c7e144ba0b37aea24995af391907R166) -> [L175](https://github.com/Webserve4242/webserv/pull/22/commits/e80ab7eac330a8efa3d8e17b7ca5164fbdca52de#diff-cc7b297cf0a88731c75c91292f140e78d982c7e144ba0b37aea24995af391907R175) -> [L181](https://github.com/Webserve4242/webserv/pull/22/commits/e80ab7eac330a8efa3d8e17b7ca5164fbdca52de#diff-cc7b297cf0a88731c75c91292f140e78d982c7e144ba0b37aea24995af391907R181-R204)
- [x] `recv()` [L166](https://github.com/Webserve4242/webserv/pull/22/commits/e80ab7eac330a8efa3d8e17b7ca5164fbdca52de#diff-cc7b297cf0a88731c75c91292f140e78d982c7e144ba0b37aea24995af391907R166) -> [L177](https://github.com/Webserve4242/webserv/pull/22/commits/e80ab7eac330a8efa3d8e17b7ca5164fbdca52de#diff-cc7b297cf0a88731c75c91292f140e78d982c7e144ba0b37aea24995af391907R177) -> [L211](https://github.com/Webserve4242/webserv/pull/22/commits/e80ab7eac330a8efa3d8e17b7ca5164fbdca52de#diff-cc7b297cf0a88731c75c91292f140e78d982c7e144ba0b37aea24995af391907R211)
- [x] `send()`  [L166](https://github.com/Webserve4242/webserv/pull/22/commits/e80ab7eac330a8efa3d8e17b7ca5164fbdca52de#diff-cc7b297cf0a88731c75c91292f140e78d982c7e144ba0b37aea24995af391907R166) -> [L177](https://github.com/Webserve4242/webserv/pull/22/commits/e80ab7eac330a8efa3d8e17b7ca5164fbdca52de#diff-cc7b297cf0a88731c75c91292f140e78d982c7e144ba0b37aea24995af391907R177) -> [L224](https://github.com/Webserve4242/webserv/pull/22/commits/e80ab7eac330a8efa3d8e17b7ca5164fbdca52de#diff-cc7b297cf0a88731c75c91292f140e78d982c7e144ba0b37aea24995af391907R224)
- [x] signal [L78](https://github.com/Webserve4242/webserv/pull/22/commits/e80ab7eac330a8efa3d8e17b7ca5164fbdca52de#diff-cc7b297cf0a88731c75c91292f140e78d982c7e144ba0b37aea24995af391907R78-R103)
  * setしているsignalは仮, ref: HTTP詳説P190
- [x] mainとの結合 [main.cpp](https://github.com/Webserve4242/webserv/pull/22/commits/e80ab7eac330a8efa3d8e17b7ca5164fbdca52de#diff-a13ed2b65aeab28cc6833534e13c600190ad97a8fe54dd1de028358404680030R3-R42)

### Client
- 0f03c1e
- テスト用にClientを追加 [Client.cpp](https://github.com/Webserve4242/webserv/pull/22/commits/0f03c1e6e27b89447d4e0e2cc9fd03d3ad20d1df#diff-d3adcf402d62dce11ee1b211e526ad53adce01ac61eda89e0a307ac4b6224cb0R1), [Client.hpp](https://github.com/Webserve4242/webserv/pull/22/commits/0f03c1e6e27b89447d4e0e2cc9fd03d3ad20d1df#diff-639c44316f615d7348f6777f5bbd7e99bc827190fd10b6a8a48f0cfdaa5c3ee2R1)
- `make client`で単体使用可 [Makefile L124](https://github.com/Webserve4242/webserv/pull/22/commits/0f03c1e6e27b89447d4e0e2cc9fd03d3ad20d1df#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R124), [client_main.cpp](https://github.com/Webserve4242/webserv/pull/22/commits/0f03c1e6e27b89447d4e0e2cc9fd03d3ad20d1df#diff-fbeef54aed1440c4803b67850b752d20c3e20ea609073e76f7f8624b1d498a95R1)
- エラーハンドリングは雑です🥹

### Test
- [x] constructor [L163](https://github.com/Webserve4242/webserv/pull/22/commits/cc52276d602a75d43f85a56f820214032cf15640#diff-d27ce08c6b796ab130e7c6d84a88f51b9fb4bf55d6e456db587b8dd5c1148ccfR163-R196)
- [x] select, epoll, kqueue [L176~](https://github.com/Webserve4242/webserv/pull/22/commits/cc52276d602a75d43f85a56f820214032cf15640#diff-d27ce08c6b796ab130e7c6d84a88f51b9fb4bf55d6e456db587b8dd5c1148ccfR176)
- accept (確かめようがない...?)
- [x] recv [L176~](https://github.com/Webserve4242/webserv/pull/22/commits/cc52276d602a75d43f85a56f820214032cf15640#diff-d27ce08c6b796ab130e7c6d84a88f51b9fb4bf55d6e456db587b8dd5c1148ccfR176)
- [x] send [L176~](https://github.com/Webserve4242/webserv/pull/22/commits/cc52276d602a75d43f85a56f820214032cf15640#diff-d27ce08c6b796ab130e7c6d84a88f51b9fb4bf55d6e456db587b8dd5c1148ccfR176)


### 他
- むやみに例外を投げないようにするため、Result型で大元までエラーを伝搬した実装とした。今のところ例外を投げるのはServerのconstructorだけのはず。
- classの宣言をシンプルにするため、クラス内でしか使わない定数や、メンバー変数にアクセスしないprivate関数は、無名名前空間に定義＆実装した


<br>

### 残課題
- exit, SIGIGNなどのsignalの選定
- conf, HttpResponse, HttpRequestなどの反映 & test追加
- test case追加など（色々ザルなはず...）

<br>

## Ref
- TLPI, HTTP詳説
- [man Kqueue](https://nxmnpg.lemoda.net/ja/2/kqueue)
- [FreeBSD Manual Pages](https://man.freebsd.org/cgi/man.cgi?query=kqueue&apropos=0&sektion=2&manpath=FreeBSD+12.0-RELEASE+and+Ports&arch=default&format=html)
- [BSDでkqueue・keventを使ってみよう](http://x68000.q-e-d.net/~68user/net/c-kqueue-1.html)
- [システムプログラム（第8週）: select()による複数のクライアントに対するサービスの同時提供](http://www.coins.tsukuba.ac.jp/~syspro/2011/2011-06-15/echo-server-select.html)
