### PR TITLE
implement) socket

### DIFF
--- a/.github/workflows/gtest.yml
+++ b/.github/workflows/gtest.yml
@@ -1,7 +1,7 @@
 name: UNIT_TEST
 on: [push]
 jobs:
-  Unit_test:
+  Linux:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -11,12 +11,32 @@ jobs:
           cmake -S . -B build -DCUSTOM_FLAGS="-D DEBUG"
           cmake --build build
 
-      - name: run all tests
-        run: ./build/unit_test 2>/dev/null
+      - name: run all tests on Linux
+        run: ./build/unit_test
 
       - uses: sarisia/actions-status-discord@v1
         if: always()
         with:
-          title: "UNIT_TEST"
+          title: "UNIT_TEST_ON_LINUX"
+          webhook: ${{ secrets.DISCORD_WEBHOOK }}
+          status: ${{ job.status }}
+
+  macOS:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: build
+        run: |
+          cmake -S . -B build -DCUSTOM_FLAGS="-D DEBUG"
+          cmake --build build
+
+      - name: run all tests on macOS
+        run: ./build/unit_test
+
+      - uses: sarisia/actions-status-discord@v1
+        if: always()
+        with:
+          title: "UNIT_TEST_ON_MACOS"
           webhook: ${{ secrets.DISCORD_WEBHOOK }}
           status: ${{ job.status }}

--- a/.gitignore
+++ b/.gitignore
@@ -8,9 +8,11 @@
 !srcs
 !srcs/Debug
 !srcs/Error
+!srcs/Socket
 !www
 !includes
 !test
+!playground
 
 !*.cpp
 !*.hpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,7 @@ include_directories(
         includes
         srcs/Debug
         srcs/Error
+        srcs/Socket
 )
 
 # webserv_srcs -----------------------------------------------------------------
@@ -41,7 +42,8 @@ set(webserv_srcs
         srcs/get_valid_config_file_path.cpp
         srcs/Debug/Debug.cpp
         srcs/Error/Error.cpp
-        )
+        srcs/Socket/Socket.cpp
+)
 
 add_executable(webserv
         srcs/main.cpp
@@ -53,7 +55,8 @@ set (unit_test_srcs
         test/unit_test/is_valid_file_path/test_get_valid_config_file_path.cpp
         test/unit_test/TestError.cpp
         test/unit_test/TestResult.cpp
-        )
+        test/unit_test/TestSocket.cpp
+)
 
 add_executable(unit_test
         ${webserv_srcs}

--- a/Makefile
+++ b/Makefile
@@ -10,9 +10,18 @@ SRCS_DIR	=	srcs
 #main
 SRCS		=	main.cpp \
 				get_valid_config_file_path.cpp
+
+#error
+ERROR_DIR	=	Error
+SRCS		+=	$(ERROR_DIR)/Error.cpp
+
 #debug
 DEBUG_DIR	=	Debug
 SRCS		+=	$(DEBUG_DIR)/Debug.cpp
+
+#socket
+SOCKET_DIR	=	Socket
+SRCS		+=	$(SOCKET_DIR)/Socket.cpp
 
 
 # OBJS -------------------------------------------------------------------------
@@ -27,7 +36,9 @@ DEPS		=	$(OBJS:%.o=%.d)
 # INCLUDES ---------------------------------------------------------------------
 INCLUDES_DIR =	includes \
 				$(SRCS_DIR)/$(DEBUG_DIR) \
-				$(SRCS_DIR)/$(ERROR_DIR)
+				$(SRCS_DIR)/$(ERROR_DIR) \
+				$(SRCS_DIR)/$(SOCKET_DIR)
+
 INCLUDES	 =	$(addprefix -I, $(INCLUDES_DIR))
 
 
@@ -56,7 +67,6 @@ re		: fclean all
 .PHONY	: lint
 lint	:
 	cpplint --recursive srcs
-
 
 .PHONY	: run_unit_test
 run_unit_test	:

--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,6 @@ run_unit_test	:
 	./build/unit_test 2>/dev/null
 	#./build/unit_test
 
-
 .PHONY	: run_result_test
 run_result_test	:
 	#rm -rf build
@@ -91,5 +90,13 @@ run_err_test	:
 	cmake -S . -B build -DCUSTOM_FLAGS="-D DEBUG"
 	cmake --build build
 	./build/unit_test --gtest_filter=ErrorMessage*
+
+.PHONY	: run_socket_test
+run_socket_test	:
+	#rm -rf build
+	cmake -S . -B build -DCUSTOM_FLAGS="-D DEBUG"
+	cmake --build build
+	./build/unit_test --gtest_filter=SocketUnitTest.*:SocketIntegrationTest.*
+
 
 -include $(DEPS)

--- a/includes/webserv.hpp
+++ b/includes/webserv.hpp
@@ -2,4 +2,7 @@
 
 #include <string>
 
+# define ERROR			(-1)
+# define OK				0
+
 std::string get_valid_config_file_path(const char *path);

--- a/includes/webserv.hpp
+++ b/includes/webserv.hpp
@@ -2,7 +2,4 @@
 
 #include <string>
 
-# define ERROR			(-1)
-# define OK				0
-
 std::string get_valid_config_file_path(const char *path);

--- a/playground/.gitignore
+++ b/playground/.gitignore
@@ -1,0 +1,5 @@
+*
+
+!.gitignore
+!*.cpp
+!*.hpp

--- a/playground/playground_socket.cpp
+++ b/playground/playground_socket.cpp
@@ -1,0 +1,69 @@
+#include <fcntl.h>
+#include <netdb.h>
+#include <sys/socket.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <cerrno>
+#include <cstring>
+#include <string>
+#include <iostream>
+
+int test_socket(const char *server_ip, const char *server_port) {
+	int errcode;
+	int socket_fd;
+	int ai_family, ai_socktype, ai_protocol;
+	struct addrinfo *addr_info;
+	struct addrinfo	hints = {};
+//	const char *server_ip = "127.0.0.1";
+//	const char *server_port = "65536";
+
+	printf("ip:%s, port:%s\n", server_ip, server_port);
+
+	hints.ai_socktype = SOCK_STREAM;
+	hints.ai_family = AF_UNSPEC;  // allows IPv4 and IPv6
+	hints.ai_flags = AI_PASSIVE | AI_NUMERICHOST | AI_NUMERICSERV;  // socket, IP, PORT
+	hints.ai_protocol = IPPROTO_TCP;
+
+	errcode = getaddrinfo(server_ip, server_port, &hints, &addr_info);
+	if (errcode != 0) {
+		std::cerr << "[Error] getaddrinfo:" << gai_strerror(errcode) << std::endl;
+		return 1;
+	}
+//	std::cout << "errcode:" << errcode << ", " <<
+
+	ai_family = addr_info->ai_family;
+	ai_socktype = addr_info->ai_socktype;
+	ai_protocol = addr_info->ai_protocol;
+	errno = 0;
+	std::cout << "socket" << std::endl;
+	socket_fd = socket(ai_family, ai_socktype, ai_protocol);
+	if (socket_fd == -1) {
+		std::cerr << "[Error] socket:" << strerror(errno) << std::endl;
+		return 1;
+	}
+
+	std::cout << "bind" << std::endl;
+	errno = 0;
+	if (bind(socket_fd, addr_info->ai_addr, addr_info->ai_addrlen) == -1) {
+		std::cerr << "[Error] bind:" << strerror(errno) << std::endl;
+		return 1;
+	}
+
+	std::cout << "listen" << std::endl;
+	if (listen(socket_fd, SOMAXCONN) == -1) {
+		std::cerr << "[Error] listen:" << strerror(errno) << std::endl;
+		return 1;
+	}
+
+	std::cout << "OK" << std::endl;
+	return 0;
+}
+
+// port 0, 0はエラーにならない
+int main() {
+	int ret1 = test_socket("255.255.255.254", "8080");
+	int ret2 = test_socket("255.255.255.254", "8080");
+
+	std::cout << "ret1:" << ret1 << std::endl;
+	std::cout << "ret2:" << ret2 << std::endl;
+}

--- a/srcs/Socket/Socket.cpp
+++ b/srcs/Socket/Socket.cpp
@@ -5,174 +5,166 @@
 #include <cerrno>
 #include <cstring>
 #include <iostream>
-#include "webserv.hpp"
+#include <string>
+#include "Error.hpp"
 #include "Socket.hpp"
 
-Socket::Socket() : _status(ERROR),
-				   _socket_fd(ERROR),
-				   _addr_info(NULL),
-				   _server_ip(SERVER_IP),
-				   _server_port(SERVER_PORT) {
-	if (create_socket() == ERROR) {
+namespace {
+	int INIT_FD = -1;
+
+	int OK = 0;
+	int GETADDRINFO_SUCCESS = 0;
+
+	int BIND_ERROR = -1;
+	int CLOSE_ERROR = -1;
+	int FCNTL_ERROR = -1;
+	int LISTEN_ERROR = -1;
+	int SETSOCKOPT_ERROR = -1;
+	int SOCKET_ERROR = -1;
+
+	void set_hints(struct addrinfo *hints) {
+		hints->ai_socktype = SOCK_STREAM;
+		hints->ai_family = AF_UNSPEC;  // allows IPv4 and IPv6
+		hints->ai_flags = AI_PASSIVE | AI_NUMERICHOST | AI_NUMERICSERV;  // socket, IP, PORT
+		hints->ai_protocol = IPPROTO_TCP;
+	}
+
+	Result<int, std::string> set_socket_opt(int socket_fd) {
+		const int		opt_val = 1;
+		const socklen_t	opt_len = sizeof(opt_val);
+
+		errno = 0;
+		if (setsockopt(socket_fd, SOL_SOCKET, SO_REUSEADDR, &opt_val, opt_len) == SETSOCKOPT_ERROR) {
+			std::string err_info = create_error_info(errno, __FILE__, __LINE__);
+			return Result<int, std::string>::err(err_info);
+		}
+		return Result<int, std::string>::ok(OK);
+	}
+
+	Result<int, std::string> close_socket_fd(int socket_fd) {
+		errno = 0;
+		if (close(socket_fd) == CLOSE_ERROR) {
+			std::string err_info = create_error_info(errno, __FILE__, __LINE__);
+			return Result<int, std::string>::err(err_info);
+		}
+		return Result<int, std::string>::ok(OK);
+	}
+}  // namespace
+
+Socket::Socket(const char *server_ip,
+			   const char *server_port) : _result(),
+			   							  _socket_fd(INIT_FD),
+										  _addr_info(NULL),
+										  _server_ip(server_ip),
+										  _server_port(server_port) {
+	this->_result = init_addr_info();
+	if (this->_result.is_err()) {
 		return;
 	}
-	if (bind_socket() == ERROR) {
+	this->_result = create_socket();
+	if (this->_result.is_err()) {
 		return;
 	}
-	if (listen_socket() == ERROR) {
+	this->_result = bind_socket();
+	if (this->_result.is_err()) {
 		return;
 	}
-	if (set_fd_to_nonblock() == ERROR) {
+	this->_result = listen_socket();
+	if (this->_result.is_err()) {
 		return;
 	}
-	this->_status = OK;
+	this->_result = set_fd_to_nonblock();
+	if (this->_result.is_err()) {
+		return;
+	}
 }
 
-Socket::Socket(const char *server_ip, const char *server_port) : _status(ERROR),
-																 _socket_fd(ERROR),
-																 _addr_info(NULL),
-																 _server_ip(server_ip),
-																 _server_port(server_port) {
-	if (create_socket() == ERROR) {
-		return;
-	}
-	if (bind_socket() == ERROR) {
-		return;
-	}
-	if (listen_socket() == ERROR) {
-		return;
-	}
-	if (set_fd_to_nonblock() == ERROR) {
-		return;
-	}
-	this->_status = OK;
-}
-
-// Socket::Socket(const Socket &copy) {
-// 	*this = copy;
-// }
-//
-// Socket &Socket::operator=(const Socket &rhs) {
-// 	if (this != &rhs) {
-// 		_status = rhs._status;
-// 		_socket_fd = rhs._socket_fd;
-// 		_server_ip = rhs._server_ip;
-// 		_server_port = rhs._server_port;
-// 		// _addr_info = rhs._addr_info;
-// 		set_addr_info(this->_server_ip, this->_server_port, &this->_addr_info);
-// 	}
-// 	return *this;
-// }
+// todo
+// Socket::Socket(const Configuration &conf) {}
 
 Socket::~Socket() {
+	Result<int, std::string> close_result;
+
 	if (this->_addr_info != NULL) {
 		freeaddrinfo(this->_addr_info);
 		this->_addr_info = NULL;
 	}
-	if (this->_socket_fd != ERROR) {
-		close_socket_fd(this->_socket_fd);
-		this->_socket_fd = ERROR;
+	if (this->_socket_fd != INIT_FD) {
+		close_result = close_socket_fd(this->_socket_fd);
+		if (close_result.is_err()) {
+			std::cerr << "close:" << close_result.get_err_value() << std::endl;
+		}
+		this->_socket_fd = INIT_FD;
 	}
-	// std::cout << "destructor" << std::endl;
 }
 
-int Socket::create_socket() {
-	int errcode;
-	int ai_family, ai_socktype, ai_protocol;
-
-	errcode = set_addr_info(this->_server_ip, this->_server_port, &this->_addr_info);
-	if (errcode != OK) {
-		std::cerr << gai_strerror(errcode) << std::endl;
-		return ERROR;
-	}
-
-	ai_family = this->_addr_info->ai_family;
-	ai_socktype = this->_addr_info->ai_socktype;
-	ai_protocol = this->_addr_info->ai_protocol;
-	errno = 0;
-	this->_socket_fd = socket(ai_family, ai_socktype, ai_protocol);
-	if (this->_socket_fd == ERROR) {
-		std::cerr << strerror(errno) << std::endl;
-		return ERROR;
-	}
-	return OK;
-}
-
-/*
- listen 192.168.1.2:80;
- listen 80;
- */
-int Socket::set_addr_info(const char *ip, const char *port, struct addrinfo **result) {
+Result<int, std::string> Socket::init_addr_info() {
 	struct addrinfo	hints = {};
 	int				errcode;
+	struct addrinfo	*ret_addr_info;
 
-	set_addr_hints(&hints);
-	errcode = getaddrinfo(ip, port, &hints, result);
-	return errcode;
-}
-
-void Socket::set_addr_hints(struct addrinfo *hints) {
-	hints->ai_socktype = SOCK_STREAM;
-	hints->ai_family = AF_UNSPEC;  // allows IPv4 and IPv6
-	hints->ai_flags = AI_PASSIVE | AI_NUMERICHOST | AI_NUMERICSERV;  // socket, IP, PORT
-	hints->ai_protocol = IPPROTO_TCP;
-}
-
-int Socket::bind_socket() const {
-	const struct sockaddr	*ai_addr;
-	socklen_t				ai_addrlen;
-
-	if (set_socket_opt(this->_socket_fd) == ERROR) {
-		return ERROR;
+	set_hints(&hints);  // todo: setting IPv4, IPv6 from config??
+	errcode = getaddrinfo(this->_server_ip, this->_server_port, &hints, &ret_addr_info);
+	if (errcode != GETADDRINFO_SUCCESS) {
+		std::string err_info = create_error_info(gai_strerror(errcode), __FILE__, __LINE__);
+		return Result<int, std::string>::err("getaddrinfo:" + err_info);
 	}
-	ai_addr = this->_addr_info->ai_addr;
-	ai_addrlen = this->_addr_info->ai_addrlen;
-	errno = 0;
-	if (bind(this->_socket_fd, ai_addr, ai_addrlen) == ERROR) {
-		std::cerr << strerror(errno) << std::endl;
-		return ERROR;
-	}
-	return OK;
+	this->_addr_info = ret_addr_info;
+	return Result<int, std::string>::ok(OK);
 }
 
-int Socket::set_socket_opt(int socket_fd) {
-	int			opt_val = 1;
-	socklen_t	opt_len = sizeof(opt_val);
+Result<int, std::string> Socket::create_socket() {
+	const int	ai_family = this->_addr_info->ai_family;
+	const int	ai_socktype = this->_addr_info->ai_socktype;
+	const int	ai_protocol = this->_addr_info->ai_protocol;
+	int			socket_fd;
 
 	errno = 0;
-	if (setsockopt(socket_fd, SOL_SOCKET, SO_REUSEADDR, &opt_val, opt_len) == ERROR) {
-		std::cout << strerror(errno) << std::endl;
-		return ERROR;
+	socket_fd = socket(ai_family, ai_socktype, ai_protocol);
+	if (socket_fd == SOCKET_ERROR) {
+		std::string err_info = create_error_info(errno, __FILE__, __LINE__);
+		return Result<int, std::string>::err("socket:" + err_info);
 	}
-	return OK;
+	this->_socket_fd = socket_fd;
+	return Result<int, std::string>::ok(OK);
 }
 
-int Socket::listen_socket() const {
-	errno = 0;
-	if (listen(this->_socket_fd, SOMAXCONN) == ERROR) {
-		std::cerr << strerror(errno) << std::endl;
-		return ERROR;
+Result<int, std::string> Socket::bind_socket() const {
+	Result<int, std::string>	set_opt_result;
+	const struct sockaddr		*ai_addr = this->_addr_info->ai_addr;
+	const socklen_t				ai_addrlen = this->_addr_info->ai_addrlen;
+
+	set_opt_result = set_socket_opt(this->_socket_fd);
+	if (set_opt_result.is_err()) {
+		return set_opt_result;
 	}
-	return OK;
+
+	errno = 0;
+	if (bind(this->_socket_fd, ai_addr, ai_addrlen) == BIND_ERROR) {
+		std::string err_info = create_error_info(errno, __FILE__, __LINE__);
+		return Result<int, std::string>::err("bind:" + err_info);
+	}
+	return Result<int, std::string>::ok(OK);
 }
 
-int Socket::set_fd_to_nonblock() const {
+Result<int, std::string> Socket::listen_socket() const {
 	errno = 0;
-	if (fcntl(this->_socket_fd, F_SETFL, O_NONBLOCK | FD_CLOEXEC) == ERROR) {
-		std::cerr << strerror(errno) << std::endl;
-		return ERROR;
+	if (listen(this->_socket_fd, SOMAXCONN) == LISTEN_ERROR) {
+		std::string err_info = create_error_info(errno, __FILE__, __LINE__);
+		return Result<int, std::string>::err("listen:" + err_info);
 	}
-	return OK;
+	return Result<int, std::string>::ok(OK);
 }
 
-void Socket::close_socket_fd(int socket_fd) {
+Result<int, std::string> Socket::set_fd_to_nonblock() const {
 	errno = 0;
-	if (close(socket_fd) == ERROR) {
-		std::cerr << strerror(errno) << std::endl;
+	if (fcntl(this->_socket_fd, F_SETFL, O_NONBLOCK | FD_CLOEXEC) == FCNTL_ERROR) {
+		std::string err_info = create_error_info(errno, __FILE__, __LINE__);
+		return Result<int, std::string>::err("fcntl:" + err_info);
 	}
+	return Result<int, std::string>::ok(OK);
 }
 
 int Socket::get_socket_fd() const { return this->_socket_fd; }
-int Socket::get_status() const { return this->_status; }
-// std::string Socket::get_server_port() const { return this->_server_port; }
-// std::string Socket::get_server_ip() const { return this->_server_ip; }
+Result<int, std::string> Socket::get_socket_result() const { return this->_result; }
+bool Socket::is_socket_success() const { return this->_result.is_ok(); }

--- a/srcs/Socket/Socket.cpp
+++ b/srcs/Socket/Socket.cpp
@@ -1,0 +1,178 @@
+#include <fcntl.h>
+#include <netdb.h>
+#include <sys/socket.h>
+#include <unistd.h>
+#include <cerrno>
+#include <cstring>
+#include <iostream>
+#include "webserv.hpp"
+#include "Socket.hpp"
+
+Socket::Socket() : _status(ERROR),
+				   _socket_fd(ERROR),
+				   _addr_info(NULL),
+				   _server_ip(SERVER_IP),
+				   _server_port(SERVER_PORT) {
+	if (create_socket() == ERROR) {
+		return;
+	}
+	if (bind_socket() == ERROR) {
+		return;
+	}
+	if (listen_socket() == ERROR) {
+		return;
+	}
+	if (set_fd_to_nonblock() == ERROR) {
+		return;
+	}
+	this->_status = OK;
+}
+
+Socket::Socket(const char *server_ip, const char *server_port) : _status(ERROR),
+																 _socket_fd(ERROR),
+																 _addr_info(NULL),
+																 _server_ip(server_ip),
+																 _server_port(server_port) {
+	if (create_socket() == ERROR) {
+		return;
+	}
+	if (bind_socket() == ERROR) {
+		return;
+	}
+	if (listen_socket() == ERROR) {
+		return;
+	}
+	if (set_fd_to_nonblock() == ERROR) {
+		return;
+	}
+	this->_status = OK;
+}
+
+// Socket::Socket(const Socket &copy) {
+// 	*this = copy;
+// }
+//
+// Socket &Socket::operator=(const Socket &rhs) {
+// 	if (this != &rhs) {
+// 		_status = rhs._status;
+// 		_socket_fd = rhs._socket_fd;
+// 		_server_ip = rhs._server_ip;
+// 		_server_port = rhs._server_port;
+// 		// _addr_info = rhs._addr_info;
+// 		set_addr_info(this->_server_ip, this->_server_port, &this->_addr_info);
+// 	}
+// 	return *this;
+// }
+
+Socket::~Socket() {
+	if (this->_addr_info != NULL) {
+		freeaddrinfo(this->_addr_info);
+		this->_addr_info = NULL;
+	}
+	if (this->_socket_fd != ERROR) {
+		close_socket_fd(this->_socket_fd);
+		this->_socket_fd = ERROR;
+	}
+	// std::cout << "destructor" << std::endl;
+}
+
+int Socket::create_socket() {
+	int errcode;
+	int ai_family, ai_socktype, ai_protocol;
+
+	errcode = set_addr_info(this->_server_ip, this->_server_port, &this->_addr_info);
+	if (errcode != OK) {
+		std::cerr << gai_strerror(errcode) << std::endl;
+		return ERROR;
+	}
+
+	ai_family = this->_addr_info->ai_family;
+	ai_socktype = this->_addr_info->ai_socktype;
+	ai_protocol = this->_addr_info->ai_protocol;
+	errno = 0;
+	this->_socket_fd = socket(ai_family, ai_socktype, ai_protocol);
+	if (this->_socket_fd == ERROR) {
+		std::cerr << strerror(errno) << std::endl;
+		return ERROR;
+	}
+	return OK;
+}
+
+/*
+ listen 192.168.1.2:80;
+ listen 80;
+ */
+int Socket::set_addr_info(const char *ip, const char *port, struct addrinfo **result) {
+	struct addrinfo	hints = {};
+	int				errcode;
+
+	set_addr_hints(&hints);
+	errcode = getaddrinfo(ip, port, &hints, result);
+	return errcode;
+}
+
+void Socket::set_addr_hints(struct addrinfo *hints) {
+	hints->ai_socktype = SOCK_STREAM;
+	hints->ai_family = AF_UNSPEC;  // allows IPv4 and IPv6
+	hints->ai_flags = AI_PASSIVE | AI_NUMERICHOST | AI_NUMERICSERV;  // socket, IP, PORT
+	hints->ai_protocol = IPPROTO_TCP;
+}
+
+int Socket::bind_socket() const {
+	const struct sockaddr	*ai_addr;
+	socklen_t				ai_addrlen;
+
+	if (set_socket_opt(this->_socket_fd) == ERROR) {
+		return ERROR;
+	}
+	ai_addr = this->_addr_info->ai_addr;
+	ai_addrlen = this->_addr_info->ai_addrlen;
+	errno = 0;
+	if (bind(this->_socket_fd, ai_addr, ai_addrlen) == ERROR) {
+		std::cerr << strerror(errno) << std::endl;
+		return ERROR;
+	}
+	return OK;
+}
+
+int Socket::set_socket_opt(int socket_fd) {
+	int			opt_val = 1;
+	socklen_t	opt_len = sizeof(opt_val);
+
+	errno = 0;
+	if (setsockopt(socket_fd, SOL_SOCKET, SO_REUSEADDR, &opt_val, opt_len) == ERROR) {
+		std::cout << strerror(errno) << std::endl;
+		return ERROR;
+	}
+	return OK;
+}
+
+int Socket::listen_socket() const {
+	errno = 0;
+	if (listen(this->_socket_fd, SOMAXCONN) == ERROR) {
+		std::cerr << strerror(errno) << std::endl;
+		return ERROR;
+	}
+	return OK;
+}
+
+int Socket::set_fd_to_nonblock() const {
+	errno = 0;
+	if (fcntl(this->_socket_fd, F_SETFL, O_NONBLOCK | FD_CLOEXEC) == ERROR) {
+		std::cerr << strerror(errno) << std::endl;
+		return ERROR;
+	}
+	return OK;
+}
+
+void Socket::close_socket_fd(int socket_fd) {
+	errno = 0;
+	if (close(socket_fd) == ERROR) {
+		std::cerr << strerror(errno) << std::endl;
+	}
+}
+
+int Socket::get_socket_fd() const { return this->_socket_fd; }
+int Socket::get_status() const { return this->_status; }
+// std::string Socket::get_server_port() const { return this->_server_port; }
+// std::string Socket::get_server_ip() const { return this->_server_ip; }

--- a/srcs/Socket/Socket.hpp
+++ b/srcs/Socket/Socket.hpp
@@ -1,0 +1,37 @@
+#pragma once
+
+# define SERVER_IP		"127.0.0.1"
+# define SERVER_PORT	"8080"
+
+// todo: config -> port, protocol
+// todo: signal
+class Socket {
+ public:
+	Socket();
+	Socket(const char *server_ip, const char *server_port);
+	~Socket();
+	// Socket(const Socket &copy);  // for debug
+	// Socket &operator=(const Socket &rhs);  // for debug
+
+	int	get_socket_fd() const;
+	int	get_status() const;
+	// std::string get_server_ip() const;  // for debug
+	// std::string get_server_port() const;  // for debug
+
+ private:
+	int _status;
+	int _socket_fd;
+	struct addrinfo *_addr_info;
+	const char *_server_ip;  // Nullable
+	const char *_server_port;
+
+	int create_socket();
+	int bind_socket() const;
+	int listen_socket() const;
+	int set_fd_to_nonblock() const;
+
+	static int set_addr_info(const char *ip, const char *port, struct addrinfo **result);
+	static void set_addr_hints(struct addrinfo *hints);
+	static int set_socket_opt(int socket_fd);
+	static void close_socket_fd(int socket_fd);
+};

--- a/srcs/Socket/Socket.hpp
+++ b/srcs/Socket/Socket.hpp
@@ -1,37 +1,28 @@
 #pragma once
 
-# define SERVER_IP		"127.0.0.1"
-# define SERVER_PORT	"8080"
+# include <string>
+# include "Result.hpp"
 
-// todo: config -> port, protocol
-// todo: signal
 class Socket {
  public:
-	Socket();
 	Socket(const char *server_ip, const char *server_port);
+	// Socket(const Configuration &conf);
 	~Socket();
-	// Socket(const Socket &copy);  // for debug
-	// Socket &operator=(const Socket &rhs);  // for debug
 
 	int	get_socket_fd() const;
-	int	get_status() const;
-	// std::string get_server_ip() const;  // for debug
-	// std::string get_server_port() const;  // for debug
+	Result<int, std::string> get_socket_result() const;
+	bool is_socket_success() const;
 
  private:
-	int _status;
+	Result<int, std::string> _result;
 	int _socket_fd;
 	struct addrinfo *_addr_info;
 	const char *_server_ip;  // Nullable
 	const char *_server_port;
 
-	int create_socket();
-	int bind_socket() const;
-	int listen_socket() const;
-	int set_fd_to_nonblock() const;
-
-	static int set_addr_info(const char *ip, const char *port, struct addrinfo **result);
-	static void set_addr_hints(struct addrinfo *hints);
-	static int set_socket_opt(int socket_fd);
-	static void close_socket_fd(int socket_fd);
+	Result<int, std::string> init_addr_info();
+	Result<int, std::string> create_socket();
+	Result<int, std::string> bind_socket() const;
+	Result<int, std::string> listen_socket() const;
+	Result<int, std::string> set_fd_to_nonblock() const;
 };

--- a/test/unit_test/TestSocket.cpp
+++ b/test/unit_test/TestSocket.cpp
@@ -1,0 +1,263 @@
+#include <arpa/inet.h>
+#include <fcntl.h>
+#include <netdb.h>
+#include <sys/socket.h>
+#include <string>
+#include <vector>
+#include "gtest/gtest.h"
+#include "webserv.hpp"
+#include "Socket.hpp"
+#include "Color.hpp"
+
+static struct sockaddr_in create_addr();
+static int create_nonblock_client_fd();
+
+/* *********************** */
+/*     Socket Unit Test    */
+/* *********************** */
+TEST(SocketUnitTest, DefaultConstructor) {
+	Socket socket = Socket();
+
+	EXPECT_EQ(OK, socket.get_status());
+}
+
+TEST(SocketUnitTest, ConstructorWithArgument) {
+	Socket socket = Socket(SERVER_IP, SERVER_PORT);
+
+	EXPECT_EQ(OK, socket.get_status());
+
+}
+
+// TEST(SocketUnitTest, CopyConstructor) {
+// 	Socket socket_src = Socket(SERVER_IP, SERVER_PORT);
+// 	Socket socket_new = Socket(socket_src);
+//
+// 	EXPECT_EQ(socket_src.get_status(), socket_new.get_status());
+// 	EXPECT_EQ(socket_src.get_socket_fd(), socket_new.get_socket_fd());
+// 	EXPECT_EQ(socket_src.get_server_port(), socket_new.get_server_port());
+// 	EXPECT_EQ(socket_src.get_server_ip(), socket_new.get_server_ip());
+// }
+//
+// TEST(SocketUnitTest, CopyAssignmentConstructor) {
+// 	Socket socket_src = Socket(SERVER_IP, SERVER_PORT);
+// 	Socket socket_new = socket_src;
+//
+// 	EXPECT_EQ(socket_src.get_status(), socket_new.get_status());
+// 	EXPECT_EQ(socket_src.get_socket_fd(), socket_new.get_socket_fd());
+// 	EXPECT_EQ(socket_src.get_server_port(), socket_new.get_server_port());
+// 	EXPECT_EQ(socket_src.get_server_ip(), socket_new.get_server_ip());
+// }
+
+TEST(SocketUnitTest, ConstructorWithValidServerIP) {
+	int port = 49152;
+	Socket socket1 = Socket("127.0.0.1", std::to_string(port++).c_str());
+	Socket socket2 = Socket("0.0.0.0", std::to_string(port++).c_str());
+	Socket socket3 = Socket("000.0000.00000.000000", std::to_string(port++).c_str());
+
+	EXPECT_EQ(OK, socket1.get_status());
+	EXPECT_EQ(OK, socket2.get_status());
+	EXPECT_EQ(OK, socket3.get_status());
+
+}
+
+TEST(SocketUnitTest, ConstructorWithInvalidServerIP) {
+	int port = 49152;
+	Socket socket1 = Socket("127.0.0.0.1", std::to_string(port++).c_str());
+	Socket socket2 = Socket("256.0.0.0", std::to_string(port++).c_str());
+	Socket socket3 = Socket("-1", std::to_string(port++).c_str());
+	Socket socket4 = Socket("a.0.0.0", std::to_string(port++).c_str());
+	Socket socket5 = Socket("127:0.0.1", std::to_string(port++).c_str());
+	Socket socket6 = Socket("127,0.0.1", std::to_string(port++).c_str());
+	Socket socket7 = Socket("127.0.0.-1", std::to_string(port++).c_str());
+	Socket socket8 = Socket("2147483647.2147483647.2147483647.2147483647", std::to_string(port++).c_str());
+	// Socket socket9 = Socket("", std::to_string(port++).c_str());  todo: ok?
+	Socket socket10 = Socket("hoge", std::to_string(port++).c_str());
+	Socket socket11 = Socket("0001.0001.0001.0001", std::to_string(port++).c_str());
+	Socket socket12 = Socket("255.255.255.254", std::to_string(port++).c_str());
+	// Socket socket13 = Socket("255.255.255.255", std::to_string(port++).c_str());  // Linux OK, todo:error?
+
+	EXPECT_EQ(ERROR, socket1.get_status());
+	EXPECT_EQ(ERROR, socket2.get_status());
+	EXPECT_EQ(ERROR, socket3.get_status());
+	EXPECT_EQ(ERROR, socket4.get_status());
+	EXPECT_EQ(ERROR, socket5.get_status());
+	EXPECT_EQ(ERROR, socket6.get_status());
+	EXPECT_EQ(ERROR, socket7.get_status());
+	EXPECT_EQ(ERROR, socket8.get_status());
+	// EXPECT_EQ(ERROR, socket9.get_status());
+	EXPECT_EQ(ERROR, socket10.get_status());
+	EXPECT_EQ(ERROR, socket11.get_status());
+	EXPECT_EQ(ERROR, socket12.get_status());
+	// EXPECT_EQ(ERROR, socket13.get_status());
+}
+
+TEST(SocketUnitTest, ConstructorWithValidServerPort) {
+	Socket socket1 = Socket(SERVER_IP, "0");  // ephemeral port
+	Socket socket2 = Socket(SERVER_IP, "0000");
+	Socket socket3 = Socket(SERVER_IP, "8080");
+	Socket socket4 = Socket(SERVER_IP, "65535");
+
+	EXPECT_EQ(OK, socket1.get_status());
+	EXPECT_EQ(OK, socket2.get_status());
+	EXPECT_EQ(OK, socket3.get_status());
+	EXPECT_EQ(OK, socket4.get_status());
+}
+
+TEST(SocketUnitTest, ConstructorWithInvalidServerPort) {
+	Socket socket1 = Socket(SERVER_IP, "-1");
+//	Socket socket2 = Socket(SERVER_IP, "65536");  // uisingned short 65536->0(ephemeral port)
+	// Socket socket3 = Socket(SERVER_IP, "");	// strtol->0 (tmp)
+	Socket socket4 = Socket(SERVER_IP, "hoge");
+	Socket socket5 = Socket(SERVER_IP, "--123123");
+	Socket socket6 = Socket(SERVER_IP, "127.1");
+
+	EXPECT_EQ(ERROR, socket1.get_status());
+//	EXPECT_EQ(ERROR, socket2.get_status());
+	// EXPECT_EQ(ERROR, socket3.get_status());
+	EXPECT_EQ(ERROR, socket4.get_status());
+	EXPECT_EQ(ERROR, socket5.get_status());
+	EXPECT_EQ(ERROR, socket6.get_status());
+}
+
+TEST(SocketUnitTest, Getter) {
+	Socket socket = Socket();
+
+	EXPECT_EQ(OK, socket.get_status());
+	EXPECT_NE(ERROR, socket.get_socket_fd());
+}
+
+// TEST(SocketUnitTest, ExceedMaxFd) {
+// 	int limit = 20;
+//
+// 	struct rlimit old_limits;
+// 	if (getrlimit(RLIMIT_NOFILE, &old_limits) != 0) {
+// 		std::cerr << "getrlimit failed\n";
+// 		return;
+// 	}
+// 	printf("old_limit.cur:%llu,\n", old_limits.rlim_cur);
+//
+// 	struct rlimit new_limits;
+// 	new_limits.rlim_cur = limit;
+// 	new_limits.rlim_max = old_limits.rlim_max;
+//
+// 	printf("new_limit.cur:%llu\n", new_limits.rlim_cur);
+//
+// 	if (setrlimit(RLIMIT_NOFILE, &new_limits) != 0) {
+// 		std::cerr << "setrlimit failed\n";
+// 		return;
+// 	}
+//
+// 	int min_fd = 3;
+// 	std::vector<Socket> sockets;
+// 	for (int i = 0; i < limit + 10; ++i) {
+// 		// Socket socket = Socket(SERVER_IP, std::to_string(49152 + i).c_str());
+// 		// sockets.push_back(socket);
+// 		// sockets[i] = Socket(SERVER_IP, std::to_string(49152 + i).c_str());
+// 		sockets.push_back(Socket(SERVER_IP, std::to_string(49152 + i).c_str()));
+// 		printf("%si:%d, fd:%d, status:%d%s\n", YELLOW, i, sockets[i].get_socket_fd(), sockets[i].get_status(), RESET);
+//
+// 		if (i + min_fd <= limit) {
+// 			EXPECT_EQ(OK, sockets[i].get_status());
+// 			EXPECT_NE(ERROR, sockets[i].get_socket_fd());
+// 		} else {
+// 			EXPECT_EQ(ERROR, sockets[i].get_status());
+// 			EXPECT_EQ(ERROR, sockets[i].get_socket_fd());
+// 		}
+// 	}
+//
+// 	if (setrlimit(RLIMIT_NOFILE, &old_limits) != 0) {
+// 		std::cerr << "Restoring setrlimit failed\n";
+// 		return;
+// 	}
+//
+// 	printf("old_limit.cur:%llu\n", old_limits.rlim_cur);
+// }
+
+/* *********************** */
+/* Socket Integration Test */
+/* *********************** */
+TEST(SocketIntegrationTest, ConnectToClient) {
+	Socket server;
+
+	EXPECT_EQ(server.get_status(), OK);
+	EXPECT_NE(server.get_socket_fd(), ERROR);
+
+	int client_fd = socket(AF_INET, SOCK_STREAM, 0);
+	struct sockaddr_in addr = {};
+	addr.sin_family = AF_INET;
+	addr.sin_port = htons(std::strtol(SERVER_PORT, NULL, 10));
+	addr.sin_addr.s_addr = inet_addr(SERVER_IP);
+
+	EXPECT_EQ(connect(client_fd, (struct sockaddr *)&addr, sizeof(addr)), OK);
+
+	close(client_fd);
+}
+
+TEST(SocketIntegrationTest, ConnectTooManyClient) {
+	Socket server;
+	int client_fd;
+
+	EXPECT_EQ(OK, server.get_status());
+	EXPECT_NE(ERROR, server.get_socket_fd());
+
+	// connect under SOMAXCONN
+	std::vector<int> client_fds;
+	for (int i = 0; i < SOMAXCONN; ++i) {
+		client_fd = socket(AF_INET, SOCK_STREAM, 0);
+		// printf("cnt:%d, client_fd:%d\n", i+1, client_fd);
+
+		EXPECT_NE(ERROR, client_fd);
+
+		if (client_fd != ERROR) {
+			client_fds.push_back(client_fd);
+			struct sockaddr_in addr = create_addr();
+
+			EXPECT_EQ(OK, connect(client_fd, (struct sockaddr *)&addr, sizeof(addr)));
+		}
+	}
+
+	// connect over SOMAXCONN -> fd set to nonblock
+	client_fd = create_nonblock_client_fd();
+	// printf("cnt:%d, client_fd:%d\n", SOMAXCONN, client_fd);
+
+	EXPECT_NE(ERROR, client_fd);
+
+	if (client_fd != ERROR) {
+		client_fds.push_back(client_fd);
+		struct sockaddr_in addr = create_addr();
+
+		EXPECT_EQ(ERROR, connect(client_fd, (struct sockaddr *)&addr, sizeof(addr)));
+	}
+
+	// destruct
+	for (std::vector<int>::iterator itr = client_fds.begin(); itr != client_fds.end(); ++itr) {
+		close(*itr);
+	}
+	client_fds.clear();
+}
+
+/* helper funcs */
+static struct sockaddr_in create_addr() {
+	struct sockaddr_in addr = {};
+
+	addr.sin_family = AF_INET;
+	addr.sin_addr.s_addr = inet_addr(SERVER_IP);
+	addr.sin_port = htons(std::strtol(SERVER_PORT, NULL, 10));
+	return addr;
+}
+
+static int create_nonblock_client_fd() {
+	int client_fd;
+	int result_fcntl;
+
+	client_fd = socket(AF_INET, SOCK_STREAM, 0);
+	if (client_fd == ERROR) {
+		return ERROR;
+	}
+	result_fcntl = fcntl(client_fd, F_SETFL, O_NONBLOCK);
+	if (result_fcntl == ERROR) {
+		close(client_fd);
+		return ERROR;
+	}
+	return client_fd;
+}


### PR DESCRIPTION
#18 の続き

## 実装内容
- branch [sockets_satushi](https://github.com/Webserve4242/webserv/pull/18/commits/44636cecf5a007f021a0d3039fab60d949d6e195)の引き継ぎ実装 99e3794
  - constructor内でsocketの作成が完了するようにした（socketを作成する手順は、constructorを呼ぶだけ、他の手続きは不要）
  - [x] socket [Socket.cpp L116](https://github.com/Webserve4242/webserv/pull/25/commits/99e3794e5d080d205dce08499ca5edcd651b323b#diff-3626e4bda179615a8366628b615cd22d6979a01761fe6d81ebed793910b24c72R116)
  - [x] bind [Socket.cpp L132](https://github.com/Webserve4242/webserv/pull/25/commits/99e3794e5d080d205dce08499ca5edcd651b323b#diff-3626e4bda179615a8366628b615cd22d6979a01761fe6d81ebed793910b24c72R132)
  - [x] listen [Socket.cpp L150](https://github.com/Webserve4242/webserv/pull/25/commits/99e3794e5d080d205dce08499ca5edcd651b323b#diff-3626e4bda179615a8366628b615cd22d6979a01761fe6d81ebed793910b24c72R150)
  - [x] confの反映（とりあえず`IP`, `PORT`を直で与えることに）[Socket.cpp L58-59](https://github.com/Webserve4242/webserv/pull/25/commits/99e3794e5d080d205dce08499ca5edcd651b323b#diff-3626e4bda179615a8366628b615cd22d6979a01761fe6d81ebed793910b24c72R58)
  - [x] 関数の成否：Resultに格納
    - Socket classの関数はすべてnoexceptとし、関数の成否はResult型のresultに格納した
    - 呼び出し元のserverでresultをチェックし、エラーならserverでエラー文を出力し、終了する
  - private関数にしなくても良さそうな関数はlocal scopeに [Socket.cpp L12](https://github.com/Webserve4242/webserv/pull/25/commits/99e3794e5d080d205dce08499ca5edcd651b323b#diff-3626e4bda179615a8366628b615cd22d6979a01761fe6d81ebed793910b24c72R12)
- test 374b356
  - [x] constructor [TestSocket.cpp L56](https://github.com/Webserve4242/webserv/pull/25/commits/374b356ee2824cbfc188e0606924b28b04f7580f#diff-f721ef038ed83a40b1aeddf78401c95b1882d8b374de2a2ca424934c3766702eR56)
  - [x] getter [TestSocket.cpp L127](https://github.com/Webserve4242/webserv/pull/25/commits/374b356ee2824cbfc188e0606924b28b04f7580f#diff-f721ef038ed83a40b1aeddf78401c95b1882d8b374de2a2ca424934c3766702eR127) 
  - [x] client接続（正常系, `listen()`上限超過） [TestSocket.cpp L138-](https://github.com/Webserve4242/webserv/pull/25/commits/374b356ee2824cbfc188e0606924b28b04f7580f#diff-f721ef038ed83a40b1aeddf78401c95b1882d8b374de2a2ca424934c3766702eR138)
  - [x] macOS, Linux（一応windows環境も構築できるらしいが...）

<br>

## 残課題など
* test
  * socketをmaxfdまで作成するテストはうまくいかず。何個作ってもfd=3, デストラクタが走っている？
  * テストケースが弱いかも
  * macOS, Linuxで挙動が異なる点があった（一旦テストケースはコメントアウト）
    * PORT 0 : macはerror, LinuxはOK
    * PORT 65536 : macはerror, LinuxはOK（unsigned shortで0になっていそう)
    * IP: 255.255.255.255 : macはerror, LinuxはOK
* confの受取
  * とりあえず、最低限必要な`cahr *server_ip, char *server_port`を受け取る形としているが、confを受け取り、参照するような変更が必要になりそう
* confのバリデーション
  * socket作成で使うserverのIP, PORTのバリデーションはどこで？socket作成に失敗したらエラーで良いか？
  * 同様に、confのバリデーションは各項目を使うタイミングでないとチェックできない気がするが、それで良いのか？ 