### PR TITLE
test) leaks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,7 @@ set (unit_test_srcs
         test/unit_test/TestError.cpp
         test/unit_test/TestResult.cpp
         test/unit_test/TestSocket.cpp
+        test/unit_test/TestLeaks.cpp
 )
 
 add_executable(unit_test

--- a/test/unit_test/TestLeaks.cpp
+++ b/test/unit_test/TestLeaks.cpp
@@ -1,0 +1,10 @@
+#include <climits>
+#include <string>
+#include "gtest/gtest.h"
+
+TEST(Leaks, Leaks) {
+	int *arr = new int[10]();
+
+	EXPECT_EQ(0, arr[0]);
+	// delete[] arr;
+}

--- a/test/unit_test/TestLeaks.cpp
+++ b/test/unit_test/TestLeaks.cpp
@@ -6,5 +6,5 @@ TEST(Leaks, Leaks) {
 	int *arr = new int[10]();
 
 	EXPECT_EQ(0, arr[0]);
-	// delete[] arr;
+	delete[] arr;
 }


### PR DESCRIPTION
* address sanitizerでメモリリークは検知できる
* ただし、MacOSで動作しないため、ActionsのLinuxテストは要チェック
* Linuxのテストだけ落ちていたらメモリリークの可能性あり

---

* Actions
  - Linux: 検知されるhttps://github.com/Webserve4242/webserv/actions/runs/6216533030/job/16870478751?pr=31#step:4:103
  - MacOS(x86_64): 検知されない
* Local
  - Linux(Arm64): 検知される
  - MacOS(Arm64): 検知されない