### PR TITLE
ヘッダーに設定値の保持&getterを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,7 @@
 !test
 
 !www
-!config
+!conf
 
 !*.conf
 !*.cpp

--- a/conf/webserv.conf
+++ b/conf/webserv.conf
@@ -1,0 +1,66 @@
+events {
+} # events
+
+http {
+
+    # static file server
+    server {
+        listen          8080;
+        server_name     webserv  server;
+        root            www;
+
+        location / {
+            root        html;
+            index       index.html index.htm;
+        }
+
+        location /upload {
+            autoindex   on;
+        }
+
+        location /post {
+            limit_except POST {
+              deny      all;
+            }
+            client_max_body_size    20M;
+            root /upload;
+        }
+
+        location /delete {
+            limit_except DELETE {
+              deny      all;
+            }
+            root /upload;
+        }
+
+        error_page      404              /404.html;
+        # redirect server error pages to the static page /50x.html
+        error_page      500 502 503 504  /50x.html;
+        location = /50x.html {
+            root        www;
+        }
+
+    } # server
+
+
+    # CGI server
+    server {
+        listen          4242;
+        server_name     cgi_server;
+        root            www;
+
+        location /cgi-bin/.*\.php$ {
+           # CGIの設定
+        }
+        location /cgi-bin/.*\.py$ {
+           # CGIの設定
+        }
+        location ~ \.php$ {
+            return 404;
+        }
+        location ~ \.py$ {
+            return 404;
+        }
+    } # server
+
+} # http

--- a/srcs/Configuration/AbstractSyntaxTree/AbstractSyntaxTree.hpp
+++ b/srcs/Configuration/AbstractSyntaxTree/AbstractSyntaxTree.hpp
@@ -1,4 +1,23 @@
 #pragma once
 
+enum e_node_kind {
+	kBlockHttp,
+	kBlockServer,
+	kBlockLocation,
+	kBlockEvents,
+	kDirectiveListen,
+	kDirectiveServerName,
+	kDirectiveErrorPage,
+	kDirectiveReweite,
+	kDirectiveReturn,
+	kDirectiveAutoindex,
+	kDirectiveClientMaxBodySize,
+	kDirectiveRoot,
+	kDirectiveIndex,
+	kDirectiveCgi,
+	kDirectiveCgiPath,
+	kDirectiveCgiParam
+};
+
 class AbstractSyntaxTree {
 };

--- a/srcs/Configuration/Configuration.cpp
+++ b/srcs/Configuration/Configuration.cpp
@@ -45,38 +45,74 @@ Configuration &Configuration::operator=(const Configuration &rhs) {
 Result<int, std::string> Configuration::get_result() { return this->result_; }
 
 
-Result<std::string, std::string> Configuration::get_configration_file_contents(const char *file_path) {
-	FileHandler file_handler(file_path, CONFIG_FILE_EXTENSION);
-	Result<int, std::string> file_result;
-	std::string file_contents, error_msg;
-
-	file_result = file_handler.get_result();
-	if (file_result.is_err()) {
-		error_msg = file_result.get_err_value();
-		return Result<std::string, std::string>::err(error_msg);
-	}
-	file_contents = file_handler.get_contents();
-	return Result<std::string, std::string>::ok(file_contents);
+std::string Configuration::get_default_port() {
+	// todo: default portをhttp_config_から取得
+	return "80";
 }
 
-
-Result<std::deque<Token>, std::string> Configuration::tokenize(const std::string &conf_data) {
-	std::deque<Token> tokens;
-	(void)conf_data;
-
-	return Result<std::deque<Token>, std::string>::ok(tokens);
+std::string Configuration::get_default_server_name() {
+	// todo: default server_nameをhttp_config_から取得
+	return "";
 }
 
-
-Result<AbstractSyntaxTree, std::string> Configuration::parse(const std::deque<Token> &tokens) {
-	AbstractSyntaxTree ast;
-
-	(void)tokens;
-	return Result<AbstractSyntaxTree, std::string>::ok(ast);
+std::string Configuration::get_root(const std::string &server_name,
+									const std::string &location) {
+	(void)server_name;
+	(void)location;
+	// todo: default rootをhttp_config_から取得
+	return "www";
 }
 
+std::string Configuration::get_error_page(int status_code) {
+	(void)status_code;
+	// todo: status_codeに対応するerror_pageをhttp_config_から取得
+	return "404.html";
+}
 
-Result<int, std::string> Configuration::validate_ast(const AbstractSyntaxTree &ast) {
-	(void)ast;
-	return Result<int, std::string>::ok(OK);
+std::vector<std::string> Configuration::get_index(const std::string &server_name,
+												  const std::string &location) {
+	std::vector<std::string> index;
+	(void)server_name;
+	(void)location;
+	// todo: server_name, locationに対応するindexをhttp_config_から取得
+	index.push_back("index.html");
+	return index;
+}
+
+std::string Configuration::get_index_page(const std::string &server_name,
+										  const std::string &location) {
+	std::vector<std::string> index;
+
+	index = get_index(server_name, location);
+	// todo: はじめに見つかったindexをindex pageとして返す
+	return index[0];
+}
+
+bool Configuration::get_autoindex(const std::string &server_name,
+								  const std::string &location) {
+	(void)server_name;
+	(void)location;
+	// todo: server_name, locationに対応するautoindexをhttp_config_から取得
+	return false;
+}
+
+bool Configuration::is_method_allowed(const std::string &server_name,
+									  const std::string &location,
+									  const std::string &method) {
+	(void)server_name;
+	(void)location;
+	(void)method;
+	// todo: server_name, locationにおけるmethodの使用可否をhttp_config_から取得
+	return true;
+}
+
+std::size_t Configuration::get_max_body_size(const std::string &server_name,
+											 const std::string &location) {
+	(void)server_name;
+	(void)location;
+
+	// todo: server_name, locationで許容されるmax_body_sizeをhttp_config_から取得
+	const std::size_t KB = 1024;
+	const std::size_t MB = KB * KB;
+	return 20 * MB;
 }

--- a/srcs/Configuration/Configuration.cpp
+++ b/srcs/Configuration/Configuration.cpp
@@ -37,6 +37,7 @@ Configuration &Configuration::operator=(const Configuration &rhs) {
 		return *this;
 	}
 
+	this->http_config_ = rhs.http_config_;
 	this->result_ = rhs.result_;
 	return *this;
 }

--- a/srcs/Configuration/Configuration.cpp
+++ b/srcs/Configuration/Configuration.cpp
@@ -4,44 +4,22 @@
 #include "Constant.hpp"
 #include "FileHandler.hpp"
 #include "Token.hpp"
+#include "Parser.hpp"
 
 Configuration::Configuration(const char *file_path) {
-	Result<std::string, std::string> read_result;
-	Result<std::deque<Token>, std::string> tokenize_result;
-	Result<AbstractSyntaxTree, std::string> parse_result;
-	Result<int, std::string> validate_result;
+	Parser parser;
+	Result<int, std::string> parse_result;
 	std::string error_msg;
 
-	read_result = get_configration_file_contents(file_path);
-	if (read_result.is_err()) {
-		error_msg = read_result.get_err_value();
-		this->result_ = Result<int, std::string>::err(error_msg);
-		return;
-	}
-	this->conf_data_ = read_result.get_ok_value();
-
-	tokenize_result = tokenize(this->conf_data_);
-	if (tokenize_result.is_err()) {
-		error_msg = tokenize_result.get_err_value();
-		this->result_ = Result<int, std::string>::err(error_msg);
-		return;
-	}
-	this->tokens_ = tokenize_result.get_ok_value();
-
-	parse_result = parse(this->tokens_);
+	parser = Parser(file_path);
+	parse_result = parser.get_result();
 	if (parse_result.is_err()) {
 		error_msg = parse_result.get_err_value();
 		this->result_ = Result<int, std::string>::err(error_msg);
 		return;
 	}
-	this->ast_ = parse_result.get_ok_value();
 
-	validate_result = validate_ast(this->ast_);
-	if (validate_result.is_err()) {
-		error_msg = validate_result.get_err_value();
-		this->result_ = Result<int, std::string>::err(error_msg);
-		return;
-	}
+	this->http_config_ = parser.get_config();
 	this->result_ = Result<int, std::string>::ok(OK);
 }
 
@@ -59,9 +37,6 @@ Configuration &Configuration::operator=(const Configuration &rhs) {
 		return *this;
 	}
 
-	this->conf_data_ = rhs.conf_data_;
-	this->tokens_ = rhs.tokens_;
-	this->ast_ = rhs.ast_;
 	this->result_ = rhs.result_;
 	return *this;
 }

--- a/srcs/Configuration/Configuration.hpp
+++ b/srcs/Configuration/Configuration.hpp
@@ -19,6 +19,28 @@ class Configuration {
 
 	Result<int, std::string> get_result();
 
+
+	// getter
+	std::string get_default_port();
+	std::string get_default_server_name();
+
+	std::string get_root(const std::string &server_name,
+						 const std::string &location);
+	std::string get_error_page(int status_code);
+	std::vector<std::string> get_index(const std::string &server_name,
+									   const std::string &location);
+	std::string get_index_page(const std::string &server_name,
+							   const std::string &location);
+
+	bool get_autoindex(const std::string &server_name,
+					   const std::string &location);
+	bool is_method_allowed(const std::string &server_name,
+						   const std::string &location,
+						   const std::string &method);
+	std::size_t get_max_body_size(const std::string &server_name,
+								  const std::string &location);
+
+
 	// -- tmp: 既存のテスト用 --
 	Configuration() : ip_("127.0.0.1"), port_("8080") {}
 	void set_ip(const std::string &ip) { ip_ = ip; }

--- a/srcs/Configuration/Configuration.hpp
+++ b/srcs/Configuration/Configuration.hpp
@@ -2,6 +2,7 @@
 
 # include <deque>
 # include <string>
+# include <vector>
 # include "AbstractSyntaxTree.hpp"
 # include "Parser.hpp"
 # include "Result.hpp"
@@ -13,6 +14,7 @@ class Configuration {
 	explicit Configuration(const char *file_path);
 	Configuration(const Configuration &other);
 	~Configuration();
+
 	Configuration &operator=(const Configuration &rhs);
 
 	Result<int, std::string> get_result();
@@ -26,18 +28,11 @@ class Configuration {
 	// ------------------------
 
  private:
-	std::string conf_data_;
-	std::deque<Token> tokens_;
-	AbstractSyntaxTree ast_;
+	HttpConfig http_config_;
 	Result<int, std::string> result_;
 
 	// -- tmp: 既存のテスト用 --
 	std::string ip_;
 	std::string port_;
 	// ------------------------
-
-	static Result<std::string, std::string> get_configration_file_contents(const char *file_path);
-	static Result<std::deque<Token>, std::string> tokenize(const std::string &conf_data);
-	static Result<AbstractSyntaxTree, std::string> parse(const std::deque<Token> &tokens);
-	static Result<int, std::string> validate_ast(const AbstractSyntaxTree &ast);
 };

--- a/srcs/Configuration/Parser/Parser.cpp
+++ b/srcs/Configuration/Parser/Parser.cpp
@@ -1,1 +1,86 @@
+#include <deque>
+#include "Constant.hpp"
+#include "FileHandler.hpp"
 #include "Parser.hpp"
+
+Parser::Parser(const char *file_path) {
+	Result<std::string, std::string> read_result;
+	Result<std::deque<Token>, std::string> tokenize_result;
+	Result<AbstractSyntaxTree, std::string> parse_result;
+	Result<int, std::string> validate_result;
+	std::string conf_data, error_msg;
+	std::deque<Token> tokens;
+	AbstractSyntaxTree ast;
+
+	read_result = get_configration_file_contents(file_path);
+	if (read_result.is_err()) {
+		error_msg = read_result.get_err_value();
+		this->result_ = Result<int, std::string>::err(error_msg);
+		return;
+	}
+	conf_data = read_result.get_ok_value();
+
+	tokenize_result = tokenize(conf_data);
+	if (tokenize_result.is_err()) {
+		error_msg = tokenize_result.get_err_value();
+		this->result_ = Result<int, std::string>::err(error_msg);
+		return;
+	}
+	tokens = tokenize_result.get_ok_value();
+
+	parse_result = parse(tokens);
+	if (parse_result.is_err()) {
+		error_msg = parse_result.get_err_value();
+		this->result_ = Result<int, std::string>::err(error_msg);
+		return;
+	}
+	ast = parse_result.get_ok_value();
+
+	validate_result = validate_ast(ast);
+	if (validate_result.is_err()) {
+		error_msg = validate_result.get_err_value();
+		this->result_ = Result<int, std::string>::err(error_msg);
+		return;
+	}
+
+	// ast -> http_config_
+
+	this->result_ = Result<int, std::string>::ok(OK);
+}
+
+
+Result<std::string, std::string> Parser::get_configration_file_contents(const char *file_path) {
+	FileHandler file_handler(file_path, CONFIG_FILE_EXTENSION);
+	Result<int, std::string> file_result;
+	std::string file_contents, error_msg;
+
+	file_result = file_handler.get_result();
+	if (file_result.is_err()) {
+		error_msg = file_result.get_err_value();
+		return Result<std::string, std::string>::err(error_msg);
+	}
+	file_contents = file_handler.get_contents();
+	return Result<std::string, std::string>::ok(file_contents);
+}
+
+
+Result<std::deque<Token>, std::string> Parser::tokenize(const std::string &conf_data) {
+	std::deque<Token> tokens;
+	(void)conf_data;
+
+	return Result<std::deque<Token>, std::string>::ok(tokens);
+}
+
+
+Result<AbstractSyntaxTree, std::string> Parser::parse(const std::deque<Token> &tokens) {
+	AbstractSyntaxTree ast;
+
+	(void)tokens;
+	return Result<AbstractSyntaxTree, std::string>::ok(ast);
+}
+
+
+Result<int, std::string> Parser::validate_ast(const AbstractSyntaxTree &ast) {
+	(void)ast;
+	return Result<int, std::string>::ok(OK);
+}

--- a/srcs/Configuration/Parser/Parser.cpp
+++ b/srcs/Configuration/Parser/Parser.cpp
@@ -3,6 +3,10 @@
 #include "FileHandler.hpp"
 #include "Parser.hpp"
 
+
+Parser::Parser() {}
+
+
 Parser::Parser(const char *file_path) {
 	Result<std::string, std::string> read_result;
 	Result<std::deque<Token>, std::string> tokenize_result;
@@ -49,6 +53,24 @@ Parser::Parser(const char *file_path) {
 }
 
 
+Parser::Parser(const Parser &other) {
+	*this = other;
+}
+
+
+Parser::~Parser() {}
+
+
+Parser &Parser::operator=(const Parser &rhs) {
+	if (this == &rhs) {
+		return *this;
+	}
+	this->http_config_ = rhs.http_config_;
+	this->result_ = rhs.result_;
+	return *this;
+}
+
+
 Result<std::string, std::string> Parser::get_configration_file_contents(const char *file_path) {
 	FileHandler file_handler(file_path, CONFIG_FILE_EXTENSION);
 	Result<int, std::string> file_result;
@@ -84,3 +106,8 @@ Result<int, std::string> Parser::validate_ast(const AbstractSyntaxTree &ast) {
 	(void)ast;
 	return Result<int, std::string>::ok(OK);
 }
+
+
+Result<int, std::string> Parser::get_result() const { return result_; }
+
+HttpConfig Parser::get_config() const { return http_config_; }

--- a/srcs/Configuration/Parser/Parser.hpp
+++ b/srcs/Configuration/Parser/Parser.hpp
@@ -32,7 +32,7 @@ class Parser {
 	Parser &operator=(const Parser &rhs);
 
 	Result<int, std::string> get_result() const;
-	HttpConfig get_config();
+	HttpConfig get_config() const;
 
  private:
 	HttpConfig http_config_;

--- a/srcs/Configuration/Parser/Parser.hpp
+++ b/srcs/Configuration/Parser/Parser.hpp
@@ -1,23 +1,45 @@
 #pragma once
 
-enum e_node_kind {
-	kBlockHttp,
-	kBlockServer,
-	kBlockLocation,
-	kBlockEvents,
-	kDirectiveListen,
-	kDirectiveServerName,
-	kDirectiveErrorPage,
-	kDirectiveReweite,
-	kDirectiveReturn,
-	kDirectiveAutoindex,
-	kDirectiveClientMaxBodySize,
-	kDirectiveRoot,
-	kDirectiveIndex,
-	kDirectiveCgi,
-	kDirectiveCgiPath,
-	kDirectiveCgiParam
+# include <deque>
+# include <string>
+# include <vector>
+# include "AbstractSyntaxTree.hpp"
+# include "Token.hpp"
+# include "Result.hpp"
+
+struct LocationConfig {
+	std::string path;
+	std::string root;
+};
+
+struct ServerConfig {
+	std::string listen;
+	std::string server_name;
+	std::vector<LocationConfig> locations;
+};
+
+struct HttpConfig {
+	std::vector<ServerConfig> servers;
 };
 
 class Parser {
+ public:
+	Parser();
+	explicit Parser(const char *file_path);
+	Parser(const Parser &other);
+	~Parser();
+
+	Parser &operator=(const Parser &rhs);
+
+	Result<int, std::string> get_result() const;
+	HttpConfig get_config();
+
+ private:
+	HttpConfig http_config_;
+	Result<int, std::string> result_;
+
+	static Result<std::string, std::string> get_configration_file_contents(const char *file_path);
+	static Result<std::deque<Token>, std::string> tokenize(const std::string &conf_data);
+	static Result<AbstractSyntaxTree, std::string> parse(const std::deque<Token> &tokens);
+	static Result<int, std::string> validate_ast(const AbstractSyntaxTree &ast);
 };


### PR DESCRIPTION
#39 への機能追加

* #40 でやっておくべきでした...（confの読み取りまでしか頭になかった）

## 作業内容
* `.conf`の記入例を追加 ed455e8
  - 正規表現やCGIの設定項目などは曖昧
  - 使用しそうなパラメータを全て記入した -> getterの仕様検討に
* `.conf`の設定値を保持する構造体を追加
  - 宣言はParser.hppに集約（膨らんできたらファイル分けるかも）
  - http blockを`struct http_config` に格納するイメージ
  - 構造や変数は仮で、今後追加変更していく予定
  - events blockはひとまず無視する方向とした
* Configuration classの機能を変更 
  - Configurationの役割を`.conf`の設定値の保持 & 取得とした
  - `.conf`のopen ~ parseの役割をParser classに移動 f9c007e
  - 各設定値用のgetterを追加
* `.conf`の設定値のgetterを追加  fefa336
  - getterはHTTP Responseで使いそうなものを作成（仮） 
  - http_configの構造を意識せず、いくつかの引数で設定値を取得できるようにしたい
  - 引数に`server_name`, `location`などを渡し、blockを絞っていけば設定値が取得できそう
  - ex) `server_name = webserv`, `location = /` -> `root = html`
      ```
       server {
          listen          8080;
          server_name     webserv;
       
          location / {
             root         html;
          }
       }
      ```
  - `location(path)`のマッチング解決前後は未定

<br>

## Reference
* なし

<br>

## レビューで重点的に確認していただきたい点
* getter : HTTP Responseで使いそうで不足していそうなgetterがあれば追加します
* 進めると色々変わりそうなので、根本的に危険そうな箇所があれば、ご指摘いただけると嬉しいです。
