### PR TITLE
Update config

### DIFF
--- a/.github/workflows/ai-pr-reviewer.yml
+++ b/.github/workflows/ai-pr-reviewer.yml
@@ -1,4 +1,4 @@
-name: ai-pr-reviewer
+name: Code Review
 
 permissions:
   contents: read
@@ -6,26 +6,21 @@ permissions:
 
 on:
   pull_request:
-    types: [opened]
-    branches-ignore:
-      - master
-      - main
   pull_request_review_comment:
-    types: [created]
-  issue_comment:
     types: [created]
 
 concurrency:
-  group: ${{ github.repository }}-${{ github.event.number || github.head_ref || github.sha }}-${{ github.workflow }}-${{ github.event_name == 'pull_request_review_comment' && 'pr_comment' || 'pr' }}
+  group:
+    ${{ github.repository }}-${{ github.event.number || github.head_ref ||
+    github.sha }}-${{ github.workflow }}-${{ github.event_name ==
+    'pull_request_review_comment' && 'pr_comment' || 'pr' }}
   cancel-in-progress: ${{ github.event_name != 'pull_request_review_comment' }}
 
 jobs:
   review:
     runs-on: ubuntu-latest
-    if: (github.event_name == 'issue_comment' && contains(github.event.comment.body, '[run review]') && github.event.issue.pull_request) ||　(github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '[run review]')) || (github.event_name == 'pull_request' && !contains(github.event.pull_request.title, 'release') && !contains(github.event.pull_request.title, 'Release'))
-    timeout-minutes: 15
     steps:
-      - uses: coderabbitai/openai-pr-reviewer@latest
+      - uses: coderabbitai/ai-pr-reviewer@latest
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
@@ -33,45 +28,3 @@ jobs:
           debug: false
           review_simple_changes: false
           review_comment_lgtm: false
-          openai_light_model: gpt-4 # 好みで変更
-          openai_heavy_model: gpt-4 # 好みで変更
-          openai_timeout_ms: 900000 # 15分.
-          language: ja-JP
-          path_filters: |
-            !db/**
-            !**/*.lock
-          system_message: |
-            あなたは @coderabbitai（別名 github-actions[bot]）で、OpenAIによって訓練された言語モデルです。
-            あなたの目的は、非常に経験豊富なソフトウェアエンジニアとして機能し、コードの一部を徹底的にレビューし、
-            以下のようなキーエリアを改善するためのコードスニペットを提案することです：
-              - ロジック
-              - セキュリティ
-              - パフォーマンス
-              - データ競合
-              - 一貫性
-              - エラー処理
-              - 保守性
-              - モジュール性
-              - 複雑性
-              - 最適化
-              - ベストプラクティス: DRY, SOLID, KISS
-
-            些細なコードスタイルの問題や、コメント・ドキュメントの欠落についてはコメントしないでください。
-            重要な問題を特定し、解決して全体的なコード品質を向上させることを目指してくださいが、細かい問題は意図的に無視してください。
-          summarize: |
-            次の内容でmarkdownフォーマットを使用して、最終的な回答を提供してください。
-
-              - *ウォークスルー*: 特定のファイルではなく、全体の変更に関する高レベルの要約を80語以内で。
-              - *変更点*: ファイルとその要約のテーブル。スペースを節約するために、同様の変更を持つファイルを1行にまとめることができます。
-
-            GitHubのプルリクエストにコメントとして追加されるこの要約には、追加のコメントを避けてください。
-          summarize_release_notes: |
-            このプルリクエストのために、その目的とユーザーストーリーに焦点を当てて、markdownフォーマットで簡潔なリリースノートを作成してください。
-            変更は次のように分類し箇条書きにすること:
-              "New Feature", "Bug fix", "Documentation", "Refactor", "Style",
-              "Test", "Chore", "Revert"
-            例えば:
-            ```
-            - New Feature: UIに統合ページが追加されました
-            ```
-            回答は50-100語以内にしてください。この回答はそのままリリースノートに使用されるので、追加のコメントは避けてください。

--- a/conf/webserv.conf
+++ b/conf/webserv.conf
@@ -8,6 +8,7 @@ http {
         listen          8080;
         server_name     webserv  server;
         root            www;
+        index           index.html index.htm;
 
         location / {
             root        html;

--- a/srcs/Configuration/Parser/ConfigStruct.hpp
+++ b/srcs/Configuration/Parser/ConfigStruct.hpp
@@ -145,8 +145,14 @@ struct LocationConfig : public DefaultConfig {
     LimitExceptDirective limit_except;
 
     LocationConfig()
-        : redirection(),
-          limit_except() {}
+            : redirection(),
+              limit_except() {}
+
+    LocationConfig(const DefaultConfig &other)
+            : DefaultConfig(other),
+              redirection(),
+              limit_except() {}
+
 };
 
 struct ServerConfig : public DefaultConfig  {

--- a/srcs/Configuration/Parser/ConfigStruct.hpp
+++ b/srcs/Configuration/Parser/ConfigStruct.hpp
@@ -148,11 +148,10 @@ struct LocationConfig : public DefaultConfig {
             : redirection(),
               limit_except() {}
 
-    LocationConfig(const DefaultConfig &other)
+    explicit LocationConfig(const DefaultConfig &other)
             : DefaultConfig(other),
               redirection(),
               limit_except() {}
-
 };
 
 struct ServerConfig : public DefaultConfig  {

--- a/srcs/Configuration/Parser/Parser.hpp
+++ b/srcs/Configuration/Parser/Parser.hpp
@@ -10,7 +10,8 @@
 # include "Result.hpp"
 
 
-typedef std::deque<Token>::const_iterator TokenConstItr;
+typedef std::deque<Token>::const_iterator TokenItr;
+typedef std::map<LocationPath, TokenItr> LocationItrMap;
 
 class Parser {
  public:
@@ -39,126 +40,133 @@ class Parser {
 	void set_default_server();
 
 	// Recursive descent parse func
-    static bool is_at_end(TokenConstItr *current, const TokenConstItr end);
-    static bool consume(TokenConstItr *current, const TokenConstItr end, const std::string &expected_str);
-    static bool consume(TokenConstItr *current, const TokenConstItr end, TokenKind expected_kind);
-    static bool expect(TokenConstItr *current, const TokenConstItr end, const std::string &expected_str);
-    static bool expect(TokenConstItr *current, const TokenConstItr end, TokenKind expected_kind);
-    static void skip_comments(TokenConstItr *current, const TokenConstItr end);
+    static bool is_at_end(TokenItr *current, const TokenItr end);
+    static bool consume(TokenItr *current, const TokenItr end, const std::string &expected_str);
+    static bool consume(TokenItr *current, const TokenItr end, TokenKind expected_kind);
+    static bool expect(TokenItr *current, const TokenItr end, const std::string &expected_str);
+    static bool expect(TokenItr *current, const TokenItr end, TokenKind expected_kind);
+    static void skip_comments(TokenItr *current, const TokenItr end);
 
 	// parse block
-    static Result<int, std::string> parse_http_block(TokenConstItr *current,
-                                                     const TokenConstItr end,
+    static Result<int, std::string> parse_http_block(TokenItr *current,
+                                                     const TokenItr end,
                                                      HttpConfig *http_config);
 
-    static Result<int, std::string> parse_server_block(TokenConstItr *current,
-                                                       const TokenConstItr end,
+    static Result<int, std::string> parse_server_block(TokenItr *current,
+                                                       const TokenItr end,
                                                        ServerConfig *server_config);
 
-    static Result<int, std::string> parse_location(TokenConstItr *current,
-                                                   const TokenConstItr end,
-                                                   std::map<std::string, LocationConfig> *locations);
+    static Result<int, std::string> skip_location(TokenItr *current,
+                                                  const TokenItr end,
+                                                  LocationItrMap *location_iterators);
 
-    static Result<int, std::string> parse_location_block(TokenConstItr *current,
-                                                         const TokenConstItr end,
+
+    static Result<int, std::string> parse_location(const LocationItrMap &location_iterators,
+                                                   const LocationConfig &init_config,
+                                                   const TokenItr end,
+                                                   std::map<LocationPath, LocationConfig> *locations);
+
+
+    static Result<int, std::string> parse_location_block(TokenItr *current,
+                                                         const TokenItr end,
                                                          LocationConfig *location_config);
 
-	static Result<std::string, std::string> parse_location_path(TokenConstItr *current,
-																const TokenConstItr end);
+	static Result<std::string, std::string> parse_location_path(TokenItr *current,
+                                                                const TokenItr end);
 
-    static Result<int, std::string> parse_default_config(TokenConstItr *current,
-                                                         const TokenConstItr end,
+    static Result<int, std::string> parse_default_config(TokenItr *current,
+                                                         const TokenItr end,
                                                          DefaultConfig *default_config);
 
-	static Result<int, std::string> skip_events_block(TokenConstItr *current,
-													  const TokenConstItr end);
+	static Result<int, std::string> skip_events_block(TokenItr *current,
+                                                      const TokenItr end);
 
 
 	// parse directive
-	static Result<int, std::string> parse_directive_param(TokenConstItr *current,
-														  const TokenConstItr end,
-														  std::string *param,
-														  const std::string &directive_name);
+	static Result<int, std::string> parse_directive_param(TokenItr *current,
+                                                          const TokenItr end,
+                                                          std::string *param,
+                                                          const std::string &directive_name);
 
-	static Result<int, std::string> parse_directive_params(TokenConstItr *current,
-                                                           const TokenConstItr end,
+	static Result<int, std::string> parse_directive_params(TokenItr *current,
+                                                           const TokenItr end,
                                                            std::vector<std::string> *params,
                                                            const std::string &directive_name);
 
-	static Result<int, std::string> parse_set_params(TokenConstItr *current,
-		                                             const TokenConstItr end,
-		                                             std::set<std::string> *params,
-		                                             const std::string &name);
+	static Result<int, std::string> parse_set_params(TokenItr *current,
+                                                     const TokenItr end,
+                                                     std::set<std::string> *params,
+                                                     const std::string &name);
 
-	static Result<int, std::string> parse_listen_directive(TokenConstItr *current,
-                                                           const TokenConstItr end,
+	static Result<int, std::string> parse_listen_directive(TokenItr *current,
+                                                           const TokenItr end,
                                                            std::vector<ListenDirective> *listen_directives);
 
-    static Result<int, std::string> parse_return_directive(TokenConstItr *current,
-                                                           const TokenConstItr end,
+    static Result<int, std::string> parse_return_directive(TokenItr *current,
+                                                           const TokenItr end,
                                                            ReturnDirective *redirection);
 
-    static Result<int, std::string> parse_root_directive(TokenConstItr *current,
-                                                         const TokenConstItr end,
+    static Result<int, std::string> parse_root_directive(TokenItr *current,
+                                                         const TokenItr end,
                                                          std::string *root_path);
 
-    static Result<int, std::string> parse_limit_except_directive(TokenConstItr *current,
-                                                                 const TokenConstItr end,
+    static Result<int, std::string> parse_limit_except_directive(TokenItr *current,
+                                                                 const TokenItr end,
                                                                  LimitExceptDirective *limit_except);
 
-	static Result<int, std::string> parse_access_rule(TokenConstItr *current,
-													  const TokenConstItr end,
-													  std::vector<AccessRule> *rules,
-													  const std::string &name);
+	static Result<int, std::string> parse_access_rule(TokenItr *current,
+                                                      const TokenItr end,
+                                                      std::vector<AccessRule> *rules,
+                                                      const std::string &name);
 
-    static Result<int, std::string> parse_error_page_directive(TokenConstItr *current,
-                                                               const TokenConstItr end,
+    static Result<int, std::string> parse_error_page_directive(TokenItr *current,
+                                                               const TokenItr end,
                                                                std::map<StatusCode, std::string> *error_pages);
 
-    static Result<int, std::string> parse_autoindex_directive(TokenConstItr *current,
-                                                              const TokenConstItr end,
+    static Result<int, std::string> parse_autoindex_directive(TokenItr *current,
+                                                              const TokenItr end,
                                                               bool *autoindex);
 
-    static Result<int, std::string> parse_body_size_directive(TokenConstItr *current,
-                                                              const TokenConstItr end,
+    static Result<int, std::string> parse_body_size_directive(TokenItr *current,
+                                                              const TokenItr end,
                                                               std::size_t *max_body_size_bytes);
 
 	// mv to utility ?
 	static bool is_valid_error_code(StatusCode code);
 	static bool is_valid_return_code(StatusCode code);
-	static bool is_access_rule_directive(TokenConstItr *current, const TokenConstItr end);
+	static bool is_access_rule_directive(TokenItr *current, const TokenItr end);
 	static Result<Method, std::string> get_method(const std::string &method);
 	static Result<AddressPortPair, int> parse_listen_param(const std::string &param);
 	static Result<std::size_t, int> parse_size_with_prefix(const std::string &size_str);
 
 	// error message
-	static std::string create_syntax_err_msg(const TokenConstItr current,
-											 const TokenConstItr end,
+	static std::string create_syntax_err_msg(const TokenItr current,
+											 const TokenItr end,
 											 const std::string &expecting);
 
-	static std::string create_syntax_err_msg(const TokenConstItr current,
-											 const  TokenConstItr end);
+	static std::string create_syntax_err_msg(const TokenItr current,
+											 const  TokenItr end);
 
-	static std::string create_invalid_value_err_msg(const TokenConstItr current,
-													const TokenConstItr end);
+	static std::string create_invalid_value_err_msg(const TokenItr current,
+													const TokenItr end);
 
-	static std::string create_invalid_value_err_msg(const TokenConstItr current,
-													const TokenConstItr end,
+	static std::string create_invalid_value_err_msg(const TokenItr current,
+													const TokenItr end,
 													const std::string &directive_name);
 
 	static std::string create_invalid_value_err_msg(const std::string &invalid_value,
 													const std::string &directive_name);
 
-	static std::string create_invalid_num_of_arg_err_msg(const TokenConstItr current,
-														 const TokenConstItr end,
+	static std::string create_invalid_num_of_arg_err_msg(const TokenItr current,
+														 const TokenItr end,
 														 const std::string &directive_name);
-	static std::string create_duplicated_directive_err_msg(const TokenConstItr current,
-												           const TokenConstItr end,
+	static std::string create_duplicated_directive_err_msg(const TokenItr current,
+												           const TokenItr end,
 												           const std::string &directive_name);
-	static std::string create_duplicated_location_err_msg(const TokenConstItr current,
-														  const TokenConstItr end,
+	static std::string create_duplicated_location_err_msg(const TokenItr current,
+														  const TokenItr end,
 														  const std::string &directive_name);
-	static std::string create_recursive_location_err_msg(const TokenConstItr current,
-														 const TokenConstItr end,
+	static std::string create_recursive_location_err_msg(const TokenItr current,
+														 const TokenItr end,
 														 const std::string &outside);
 };

--- a/test/test_conf/ng/ng_location_block/loccation_ng15.conf
+++ b/test/test_conf/ng/ng_location_block/loccation_ng15.conf
@@ -1,0 +1,13 @@
+events {}
+
+http {
+    server {
+        server_name a;
+
+        location a {
+           limit_except GET {
+                allow 127.0.0.1;
+                deny all;
+                server { }  # ng
+            }
+        }

--- a/test/test_conf/ng/ng_location_block/loccation_ng5.conf
+++ b/test/test_conf/ng/ng_location_block/loccation_ng5.conf
@@ -1,5 +1,5 @@
 http {
     server {
-        location server {}  # ng
+        location server { }  { }  # ng
     }
 }

--- a/test/test_conf/ok/ok_location_block/location_ok1.conf
+++ b/test/test_conf/ok/ok_location_block/location_ok1.conf
@@ -2,6 +2,6 @@ events {}
 
 http {
     server {
-        location / {}
+        location / { }
     }
 }

--- a/test/test_conf/ok/ok_location_block/location_ok2.conf
+++ b/test/test_conf/ok/ok_location_block/location_ok2.conf
@@ -2,13 +2,13 @@ events {}
 
 http {
     server {
-        location a {}
-        location b {}
+        location a { }
+        location b { }
     }
 
     server {
         listen 1;
-        location a {}
-        location b {}
+        location a { }
+        location b { }
     }
 }

--- a/test/unit_test/HttpMessageParser/TestParse.cpp
+++ b/test/unit_test/HttpMessageParser/TestParse.cpp
@@ -109,7 +109,7 @@ TEST(TestHttpMessageParser, ParsePort) {
 	EXPECT_EQ(3, end);
 
 	str = "255.255.255.255:8080";
-	//                start^   ^end
+	//                start^   ^endl
 	//     01234567890123456789
 	start = 16;
 	result = HttpMessageParser::parse_port(str, start, &end);
@@ -424,28 +424,3 @@ TEST(TestHttpMessageParser, ParseParameters) {
 	EXPECT_EQ(expected, actual);
 	EXPECT_EQ(12, end);
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/test/unit_test/TestParse.cpp
+++ b/test/unit_test/TestParse.cpp
@@ -72,29 +72,33 @@ TEST(TestParser, ParseOK) {
         {504, "/50x.html"},
     };
 
-    location_config = {};
+    // location "/"
+    location_config = LocationConfig(server_config);
     location_config.root_path = "html";
     location_config.index_pages = {"index.html", "index.htm"};
     server_config.locations["/"] = location_config;
 
-    location_config = {};
+    // location "/old.html"
+    location_config = LocationConfig(server_config);
     location_config.redirection.return_on = true;
     location_config.redirection.code = 301;
     location_config.redirection.text = "/new.html";
     server_config.locations["/old.html"] = location_config;
 
-    location_config = {};
+    // location "/upload"
+    location_config = LocationConfig(server_config);
     location_config.autoindex = true;
     server_config.locations["/upload"] = location_config;
 
-    location_config = {};
+    // location "/post"
+    location_config = LocationConfig(server_config);
     location_config.limit_except.excluded_methods = {kPOST, kDELETE};
     location_config.limit_except.rules.push_back(AccessRule(kDENY, "all"));
     location_config.max_body_size_bytes = 20 * ConfigInitValue::MB;
     location_config.root_path = "/upload";
     server_config.locations["/post"] = location_config;
 
-    location_config = {};
+    location_config = LocationConfig(server_config);
     location_config.root_path = "www";
     server_config.locations["=/50x.html"] = location_config;
 
@@ -103,6 +107,7 @@ TEST(TestParser, ParseOK) {
     actual = parser1.get_config();
     result = parser1.get_result();
 
+    // print_error_msg(result, __LINE__);
     EXPECT_TRUE(result.is_ok());
     expect_eq_http_config(expected, actual, __LINE__);
 
@@ -122,7 +127,7 @@ TEST(TestParser, ParseOK) {
 
     server_config.root_path = "www";
 
-    location_config = {};
+    location_config = LocationConfig(server_config);
     server_config.locations["^~/cgi-bin/"] = location_config;
 
     expected.servers.push_back(server_config);
@@ -130,6 +135,7 @@ TEST(TestParser, ParseOK) {
     actual = parser2.get_config();
     result = parser2.get_result();
 
+    // print_error_msg(result, __LINE__);
     EXPECT_TRUE(result.is_ok());
     expect_eq_http_config(expected, actual, __LINE__);
 
@@ -157,29 +163,29 @@ TEST(TestParser, ParseOK) {
         {504, "/50x.html"},
     };
 
-    location_config = {};
+    location_config = LocationConfig(server_config);
     location_config.root_path = "html";
     location_config.index_pages = {"index.html", "index.htm"};
     server_config.locations["/"] = location_config;
 
-    location_config = {};
+    location_config = LocationConfig(server_config);
     location_config.redirection.return_on = true;
     location_config.redirection.code = 301;
     location_config.redirection.text = "/new.html";
     server_config.locations["/old.html"] = location_config;
 
-    location_config = {};
+    location_config = LocationConfig(server_config);
     location_config.autoindex = true;
     server_config.locations["/upload"] = location_config;
 
-    location_config = {};
+    location_config = LocationConfig(server_config);
     location_config.limit_except.excluded_methods = {kPOST, kDELETE};
     location_config.limit_except.rules.push_back(AccessRule(kDENY, "all"));
     location_config.max_body_size_bytes = 20 * ConfigInitValue::MB;
     location_config.root_path = "/upload";
     server_config.locations["/post"] = location_config;
 
-    location_config = {};
+    location_config = LocationConfig(server_config);
     location_config.root_path = "www";
     server_config.locations["=/50x.html"] = location_config;
 
@@ -197,7 +203,7 @@ TEST(TestParser, ParseOK) {
 
     server_config.root_path = "www";
 
-    location_config = {};
+    location_config = LocationConfig(server_config);
     server_config.locations["^~/cgi-bin/"] = location_config;
 
     expected.servers.push_back(server_config);
@@ -205,6 +211,7 @@ TEST(TestParser, ParseOK) {
     actual = parser3.get_config();
     result = parser3.get_result();
 
+    // print_error_msg(result, __LINE__);
     EXPECT_TRUE(result.is_ok());
     expect_eq_http_config(expected, actual, __LINE__);
 }

--- a/test/unit_test/TestParserFunc.cpp
+++ b/test/unit_test/TestParserFunc.cpp
@@ -212,7 +212,7 @@ TEST(TestParser, ParseDirectiveParam) {
     const std::string test_directive = "test_param";
     std::string expected, actual;
     Result<int, std::string> result;
-    TokenConstItr current;
+    TokenItr current;
     std::deque<Token> tokens;
     int cnt;
 
@@ -270,8 +270,8 @@ TEST(TestParser, ParseDirectiveParam) {
     current = tokens.begin();
     result = ParserTestFriend::parse_directive_param(&current, tokens.end(), &actual, test_directive);
 
-    ASSERT_TRUE(result.is_err());
     print_error_msg(result, __LINE__);
+    ASSERT_TRUE(result.is_err());
 
     // -------------------------------------------------------------------------
 
@@ -281,8 +281,8 @@ TEST(TestParser, ParseDirectiveParam) {
     current = tokens.begin();
     result = ParserTestFriend::parse_directive_param(&current, tokens.end(), &actual, test_directive);
 
-    ASSERT_TRUE(result.is_err());
     print_error_msg(result, __LINE__);
+    ASSERT_TRUE(result.is_err());
 
 
     // -------------------------------------------------------------------------
@@ -295,8 +295,8 @@ TEST(TestParser, ParseDirectiveParam) {
     current = tokens.begin();
     result = ParserTestFriend::parse_directive_param(&current, tokens.end(), &actual, test_directive);
 
-    ASSERT_TRUE(result.is_err());
     print_error_msg(result, __LINE__);
+    ASSERT_TRUE(result.is_err());
 
     // -------------------------------------------------------------------------
 
@@ -311,8 +311,8 @@ TEST(TestParser, ParseDirectiveParam) {
     current = tokens.begin();
     result = ParserTestFriend::parse_directive_param(&current, tokens.end(), &actual, test_directive);
 
-    ASSERT_TRUE(result.is_err());
     print_error_msg(result, __LINE__);
+    ASSERT_TRUE(result.is_err());
 
     // -------------------------------------------------------------------------
 
@@ -324,8 +324,8 @@ TEST(TestParser, ParseDirectiveParam) {
     current = tokens.begin();
     result = ParserTestFriend::parse_directive_param(&current, tokens.end(), &actual, test_directive);
 
-    ASSERT_TRUE(result.is_err());
     print_error_msg(result, __LINE__);
+    ASSERT_TRUE(result.is_err());
 
     // -------------------------------------------------------------------------
 
@@ -337,8 +337,8 @@ TEST(TestParser, ParseDirectiveParam) {
     current = tokens.begin();
     result = ParserTestFriend::parse_directive_param(&current, tokens.end(), &actual, test_directive);
 
-    ASSERT_TRUE(result.is_err());
     print_error_msg(result, __LINE__);
+    ASSERT_TRUE(result.is_err());
 
 }
 
@@ -347,7 +347,7 @@ TEST(TestParser, ParseDirectiveParams) {
     const std::string test_directive = "test_params";
     std::vector<std::string> expected, actual;
     Result<int, std::string> result;
-    TokenConstItr current;
+    TokenItr current;
     std::deque<Token> tokens;
     int cnt;
 
@@ -397,8 +397,8 @@ TEST(TestParser, ParseDirectiveParams) {
     current = tokens.begin();
     result = ParserTestFriend::parse_directive_params(&current, tokens.end(), &actual, test_directive);
 
-    ASSERT_TRUE(result.is_err());
     print_error_msg(result, __LINE__);
+    ASSERT_TRUE(result.is_err());
 
     // -------------------------------------------------------------------------
 
@@ -410,8 +410,8 @@ TEST(TestParser, ParseDirectiveParams) {
     current = tokens.begin();
     result = ParserTestFriend::parse_directive_params(&current, tokens.end(), &actual, test_directive);
 
-    ASSERT_TRUE(result.is_err());
     print_error_msg(result, __LINE__);
+    ASSERT_TRUE(result.is_err());
 
     // -------------------------------------------------------------------------
 
@@ -421,8 +421,8 @@ TEST(TestParser, ParseDirectiveParams) {
     current = tokens.begin();
     result = ParserTestFriend::parse_directive_params(&current, tokens.end(), &actual, test_directive);
 
-    ASSERT_TRUE(result.is_err());
     print_error_msg(result, __LINE__);
+    ASSERT_TRUE(result.is_err());
 
 }
 
@@ -431,7 +431,7 @@ TEST(TestParser, ParseSetParams) {
     const std::string test_directive = "test_set_params";
     std::set<std::string> expected, actual;
     Result<int, std::string> result;
-    TokenConstItr current;
+    TokenItr current;
     std::deque<Token> tokens;
     int cnt;
 
@@ -500,8 +500,8 @@ TEST(TestParser, ParseSetParams) {
     current = tokens.begin();
     result = ParserTestFriend::parse_set_params(&current, tokens.end(), &actual, test_directive);
 
-    ASSERT_TRUE(result.is_err());
     print_error_msg(result, __LINE__);
+    ASSERT_TRUE(result.is_err());
 
     // -------------------------------------------------------------------------
 
@@ -513,8 +513,8 @@ TEST(TestParser, ParseSetParams) {
     current = tokens.begin();
     result = ParserTestFriend::parse_set_params(&current, tokens.end(), &actual, test_directive);
 
-    ASSERT_TRUE(result.is_err());
     print_error_msg(result, __LINE__);
+    ASSERT_TRUE(result.is_err());
 
     // -------------------------------------------------------------------------
 
@@ -524,8 +524,8 @@ TEST(TestParser, ParseSetParams) {
     current = tokens.begin();
     result = ParserTestFriend::parse_set_params(&current, tokens.end(), &actual, test_directive);
 
-    ASSERT_TRUE(result.is_err());
     print_error_msg(result, __LINE__);
+    ASSERT_TRUE(result.is_err());
 
 }
 
@@ -614,7 +614,7 @@ TEST(TestParser, ParseListenDirective) {
     const std::string test_directive = "test_listen";
     std::vector<ListenDirective> expected, actual;
     Result<int, std::string> result;
-    TokenConstItr current;
+    TokenItr current;
     std::deque<Token> tokens;
     int cnt;
 
@@ -772,8 +772,8 @@ TEST(TestParser, ParseListenDirective) {
     current = tokens.begin();
     result = ParserTestFriend::parse_listen_directive(&current, tokens.end(), &actual);
 
-    ASSERT_TRUE(result.is_err());
     print_error_msg(result, __LINE__);
+    ASSERT_TRUE(result.is_err());
 
     // -------------------------------------------------------------------------
 
@@ -783,8 +783,8 @@ TEST(TestParser, ParseListenDirective) {
     current = tokens.begin();
     result = ParserTestFriend::parse_listen_directive(&current, tokens.end(), &actual);
 
-    ASSERT_TRUE(result.is_err());
     print_error_msg(result, __LINE__);
+    ASSERT_TRUE(result.is_err());
 
     // -------------------------------------------------------------------------
 
@@ -798,8 +798,8 @@ TEST(TestParser, ParseListenDirective) {
     current = tokens.begin();
     result = ParserTestFriend::parse_listen_directive(&current, tokens.end(), &actual);
 
-    ASSERT_TRUE(result.is_err());
     print_error_msg(result, __LINE__);
+    ASSERT_TRUE(result.is_err());
 
     // -------------------------------------------------------------------------
 
@@ -812,8 +812,8 @@ TEST(TestParser, ParseListenDirective) {
     current = tokens.begin();
     result = ParserTestFriend::parse_listen_directive(&current, tokens.end(), &actual);
 
-    ASSERT_TRUE(result.is_err());
     print_error_msg(result, __LINE__);
+    ASSERT_TRUE(result.is_err());
 
     // -------------------------------------------------------------------------
 
@@ -826,8 +826,8 @@ TEST(TestParser, ParseListenDirective) {
     current = tokens.begin();
     result = ParserTestFriend::parse_listen_directive(&current, tokens.end(), &actual);
 
-    ASSERT_TRUE(result.is_err());
     print_error_msg(result, __LINE__);
+    ASSERT_TRUE(result.is_err());
 
     // -------------------------------------------------------------------------
 
@@ -843,8 +843,8 @@ TEST(TestParser, ParseListenDirective) {
     current = tokens.begin();
     result = ParserTestFriend::parse_listen_directive(&current, tokens.end(), &actual);
 
-    ASSERT_TRUE(result.is_err());
     print_error_msg(result, __LINE__);
+    ASSERT_TRUE(result.is_err());
 }
 
 
@@ -852,7 +852,7 @@ TEST(TestParser, ParseReturnDirective) {
     const std::string test_directive = "test_return";
     ReturnDirective expected, actual;
     Result<int, std::string> result;
-    TokenConstItr current;
+    TokenItr current;
     std::deque<Token> tokens;
     int cnt;
 
@@ -945,8 +945,8 @@ TEST(TestParser, ParseReturnDirective) {
     current = tokens.begin();
     result = ParserTestFriend::parse_return_directive(&current, tokens.end(), &actual);
 
-    ASSERT_TRUE(result.is_err());
     print_error_msg(result, __LINE__);
+    ASSERT_TRUE(result.is_err());
 
     ////////////////////////////////////////////////////////////////////////////
 
@@ -959,8 +959,8 @@ TEST(TestParser, ParseReturnDirective) {
     current = tokens.begin();
     result = ParserTestFriend::parse_return_directive(&current, tokens.end(), &actual);
 
-    ASSERT_TRUE(result.is_err());
     print_error_msg(result, __LINE__);
+    ASSERT_TRUE(result.is_err());
 
     ////////////////////////////////////////////////////////////////////////////
 
@@ -973,8 +973,8 @@ TEST(TestParser, ParseReturnDirective) {
     current = tokens.begin();
     result = ParserTestFriend::parse_return_directive(&current, tokens.end(), &actual);
 
-    ASSERT_TRUE(result.is_err());
     print_error_msg(result, __LINE__);
+    ASSERT_TRUE(result.is_err());
 
     ////////////////////////////////////////////////////////////////////////////
 
@@ -989,8 +989,8 @@ TEST(TestParser, ParseReturnDirective) {
     current = tokens.begin();
     result = ParserTestFriend::parse_return_directive(&current, tokens.end(), &actual);
 
-    ASSERT_TRUE(result.is_err());
     print_error_msg(result, __LINE__);
+    ASSERT_TRUE(result.is_err());
 
     ////////////////////////////////////////////////////////////////////////////
 
@@ -1001,8 +1001,8 @@ TEST(TestParser, ParseReturnDirective) {
     current = tokens.begin();
     result = ParserTestFriend::parse_return_directive(&current, tokens.end(), &actual);
 
-    ASSERT_TRUE(result.is_err());
     print_error_msg(result, __LINE__);
+    ASSERT_TRUE(result.is_err());
 
     ////////////////////////////////////////////////////////////////////////////
 
@@ -1014,8 +1014,8 @@ TEST(TestParser, ParseReturnDirective) {
     current = tokens.begin();
     result = ParserTestFriend::parse_return_directive(&current, tokens.end(), &actual);
 
-    ASSERT_TRUE(result.is_err());
     print_error_msg(result, __LINE__);
+    ASSERT_TRUE(result.is_err());
 
     ////////////////////////////////////////////////////////////////////////////
 
@@ -1029,8 +1029,8 @@ TEST(TestParser, ParseReturnDirective) {
     current = tokens.begin();
     result = ParserTestFriend::parse_return_directive(&current, tokens.end(), &actual);
 
-    ASSERT_TRUE(result.is_err());
     print_error_msg(result, __LINE__);
+    ASSERT_TRUE(result.is_err());
 }
 
 
@@ -1038,7 +1038,7 @@ TEST(TestParser, ParseRootDirective) {
     const std::string test_directive = "test_root";
     std::string expected, actual;
     Result<int, std::string> result;
-    TokenConstItr current;
+    TokenItr current;
     std::deque<Token> tokens;
     int cnt;
 
@@ -1093,8 +1093,8 @@ TEST(TestParser, ParseRootDirective) {
     current = tokens.begin();
     result = ParserTestFriend::parse_root_directive(&current, tokens.end(), &actual);
 
-    ASSERT_TRUE(result.is_err());
     print_error_msg(result, __LINE__);
+    ASSERT_TRUE(result.is_err());
 
     // -------------------------------------------------------------------------
 
@@ -1108,8 +1108,8 @@ TEST(TestParser, ParseRootDirective) {
     current = tokens.begin();
     result = ParserTestFriend::parse_root_directive(&current, tokens.end(), &actual);
 
-    ASSERT_TRUE(result.is_err());
     print_error_msg(result, __LINE__);
+    ASSERT_TRUE(result.is_err());
 
     // -------------------------------------------------------------------------
 
@@ -1119,8 +1119,8 @@ TEST(TestParser, ParseRootDirective) {
     current = tokens.begin();
     result = ParserTestFriend::parse_root_directive(&current, tokens.end(), &actual);
 
-    ASSERT_TRUE(result.is_err());
     print_error_msg(result, __LINE__);
+    ASSERT_TRUE(result.is_err());
 
 }
 
@@ -1129,7 +1129,7 @@ TEST(TestParser, ParseLimitExceptDirective) {
     const std::string test_directive = "test_limit_exception";
     LimitExceptDirective expected, actual;
     Result<int, std::string> result;
-    TokenConstItr current;
+    TokenItr current;
     std::deque<Token> tokens;
     int cnt;
 
@@ -1238,8 +1238,8 @@ TEST(TestParser, ParseLimitExceptDirective) {
     current = tokens.begin();
     result = ParserTestFriend::parse_limit_except_directive(&current, tokens.end(), &actual);
 
-    ASSERT_TRUE(result.is_err());
     print_error_msg(result, __LINE__);
+    ASSERT_TRUE(result.is_err());
 
     // -------------------------------------------------------------------------
 
@@ -1252,8 +1252,8 @@ TEST(TestParser, ParseLimitExceptDirective) {
     current = tokens.begin();
     result = ParserTestFriend::parse_limit_except_directive(&current, tokens.end(), &actual);
 
-    ASSERT_TRUE(result.is_err());
     print_error_msg(result, __LINE__);
+    ASSERT_TRUE(result.is_err());
 
     // -------------------------------------------------------------------------
 
@@ -1267,8 +1267,8 @@ TEST(TestParser, ParseLimitExceptDirective) {
     current = tokens.begin();
     result = ParserTestFriend::parse_limit_except_directive(&current, tokens.end(), &actual);
 
-    ASSERT_TRUE(result.is_err());
     print_error_msg(result, __LINE__);
+    ASSERT_TRUE(result.is_err());
 
     // -------------------------------------------------------------------------
 
@@ -1283,8 +1283,8 @@ TEST(TestParser, ParseLimitExceptDirective) {
     current = tokens.begin();
     result = ParserTestFriend::parse_limit_except_directive(&current, tokens.end(), &actual);
 
-    ASSERT_TRUE(result.is_err());
     print_error_msg(result, __LINE__);
+    ASSERT_TRUE(result.is_err());
 
     // -------------------------------------------------------------------------
 
@@ -1299,8 +1299,8 @@ TEST(TestParser, ParseLimitExceptDirective) {
     current = tokens.begin();
     result = ParserTestFriend::parse_limit_except_directive(&current, tokens.end(), &actual);
 
-    ASSERT_TRUE(result.is_err());
     print_error_msg(result, __LINE__);
+    ASSERT_TRUE(result.is_err());
 
     // -------------------------------------------------------------------------
 
@@ -1315,8 +1315,8 @@ TEST(TestParser, ParseLimitExceptDirective) {
     current = tokens.begin();
     result = ParserTestFriend::parse_limit_except_directive(&current, tokens.end(), &actual);
 
-    ASSERT_TRUE(result.is_err());
     print_error_msg(result, __LINE__);
+    ASSERT_TRUE(result.is_err());
 
     // -------------------------------------------------------------------------
 
@@ -1333,8 +1333,8 @@ TEST(TestParser, ParseLimitExceptDirective) {
     current = tokens.begin();
     result = ParserTestFriend::parse_limit_except_directive(&current, tokens.end(), &actual);
 
-    ASSERT_TRUE(result.is_err());
     print_error_msg(result, __LINE__);
+    ASSERT_TRUE(result.is_err());
 
     // -------------------------------------------------------------------------
 
@@ -1352,8 +1352,8 @@ TEST(TestParser, ParseLimitExceptDirective) {
     current = tokens.begin();
     result = ParserTestFriend::parse_limit_except_directive(&current, tokens.end(), &actual);
 
-    ASSERT_TRUE(result.is_err());
     print_error_msg(result, __LINE__);
+    ASSERT_TRUE(result.is_err());
 
 
 }
@@ -1363,7 +1363,7 @@ TEST(TestParser, ParseErrorPageDirective) {
     const std::string test_directive = "test_error_page";
     std::map<StatusCode, std::string> expected, actual;
     Result<int, std::string> result;
-    TokenConstItr current;
+    TokenItr current;
     std::deque<Token> tokens;
     int cnt;
 
@@ -1524,8 +1524,8 @@ TEST(TestParser, ParseErrorPageDirective) {
     current = tokens.begin();
     result = ParserTestFriend::parse_error_page_directive(&current, tokens.end(), &actual);
 
-    ASSERT_TRUE(result.is_err());
     print_error_msg(result, __LINE__);
+    ASSERT_TRUE(result.is_err());
 
     // -------------------------------------------------------------------------
 
@@ -1538,8 +1538,8 @@ TEST(TestParser, ParseErrorPageDirective) {
     current = tokens.begin();
     result = ParserTestFriend::parse_error_page_directive(&current, tokens.end(), &actual);
 
-    ASSERT_TRUE(result.is_err());
     print_error_msg(result, __LINE__);
+    ASSERT_TRUE(result.is_err());
 
     // -------------------------------------------------------------------------
 
@@ -1553,8 +1553,8 @@ TEST(TestParser, ParseErrorPageDirective) {
     current = tokens.begin();
     result = ParserTestFriend::parse_error_page_directive(&current, tokens.end(), &actual);
 
-    ASSERT_TRUE(result.is_err());
     print_error_msg(result, __LINE__);
+    ASSERT_TRUE(result.is_err());
 
     // -------------------------------------------------------------------------
 
@@ -1568,8 +1568,8 @@ TEST(TestParser, ParseErrorPageDirective) {
     current = tokens.begin();
     result = ParserTestFriend::parse_error_page_directive(&current, tokens.end(), &actual);
 
-    ASSERT_TRUE(result.is_err());
     print_error_msg(result, __LINE__);
+    ASSERT_TRUE(result.is_err());
 
     // -------------------------------------------------------------------------
 
@@ -1583,8 +1583,8 @@ TEST(TestParser, ParseErrorPageDirective) {
     current = tokens.begin();
     result = ParserTestFriend::parse_error_page_directive(&current, tokens.end(), &actual);
 
-    ASSERT_TRUE(result.is_err());
     print_error_msg(result, __LINE__);
+    ASSERT_TRUE(result.is_err());
 
     // -------------------------------------------------------------------------
 
@@ -1598,8 +1598,8 @@ TEST(TestParser, ParseErrorPageDirective) {
     current = tokens.begin();
     result = ParserTestFriend::parse_error_page_directive(&current, tokens.end(), &actual);
 
-    ASSERT_TRUE(result.is_err());
     print_error_msg(result, __LINE__);
+    ASSERT_TRUE(result.is_err());
 
     // -------------------------------------------------------------------------
 
@@ -1613,8 +1613,8 @@ TEST(TestParser, ParseErrorPageDirective) {
     current = tokens.begin();
     result = ParserTestFriend::parse_error_page_directive(&current, tokens.end(), &actual);
 
-    ASSERT_TRUE(result.is_err());
     print_error_msg(result, __LINE__);
+    ASSERT_TRUE(result.is_err());
 }
 
 
@@ -1622,7 +1622,7 @@ TEST(TestParser, ParseAutoindexDirective) {
     const std::string test_directive = "test_autoindex";
     bool actual;
     Result<int, std::string> result;
-    TokenConstItr current;
+    TokenItr current;
     std::deque<Token> tokens;
     int cnt;
 
@@ -1690,8 +1690,8 @@ TEST(TestParser, ParseAutoindexDirective) {
     current = tokens.begin();
     result = ParserTestFriend::parse_autoindex_directive(&current, tokens.end(), &actual);
 
-    ASSERT_TRUE(result.is_err());
     print_error_msg(result, __LINE__);
+    ASSERT_TRUE(result.is_err());
 
     // -------------------------------------------------------------------------
 
@@ -1705,8 +1705,8 @@ TEST(TestParser, ParseAutoindexDirective) {
     current = tokens.begin();
     result = ParserTestFriend::parse_autoindex_directive(&current, tokens.end(), &actual);
 
-    ASSERT_TRUE(result.is_err());
     print_error_msg(result, __LINE__);
+    ASSERT_TRUE(result.is_err());
 
     // -------------------------------------------------------------------------
 
@@ -1719,8 +1719,8 @@ TEST(TestParser, ParseAutoindexDirective) {
     current = tokens.begin();
     result = ParserTestFriend::parse_autoindex_directive(&current, tokens.end(), &actual);
 
-    ASSERT_TRUE(result.is_err());
     print_error_msg(result, __LINE__);
+    ASSERT_TRUE(result.is_err());
 
     // -------------------------------------------------------------------------
 
@@ -1733,8 +1733,8 @@ TEST(TestParser, ParseAutoindexDirective) {
     current = tokens.begin();
     result = ParserTestFriend::parse_autoindex_directive(&current, tokens.end(), &actual);
 
-    ASSERT_TRUE(result.is_err());
     print_error_msg(result, __LINE__);
+    ASSERT_TRUE(result.is_err());
 
     // -------------------------------------------------------------------------
 
@@ -1747,8 +1747,8 @@ TEST(TestParser, ParseAutoindexDirective) {
     current = tokens.begin();
     result = ParserTestFriend::parse_autoindex_directive(&current, tokens.end(), &actual);
 
-    ASSERT_TRUE(result.is_err());
     print_error_msg(result, __LINE__);
+    ASSERT_TRUE(result.is_err());
 
 
     // -------------------------------------------------------------------------
@@ -1762,8 +1762,8 @@ TEST(TestParser, ParseAutoindexDirective) {
     current = tokens.begin();
     result = ParserTestFriend::parse_autoindex_directive(&current, tokens.end(), &actual);
 
-    ASSERT_TRUE(result.is_err());
     print_error_msg(result, __LINE__);
+    ASSERT_TRUE(result.is_err());
 
     // -------------------------------------------------------------------------
 
@@ -1777,8 +1777,8 @@ TEST(TestParser, ParseAutoindexDirective) {
     current = tokens.begin();
     result = ParserTestFriend::parse_autoindex_directive(&current, tokens.end(), &actual);
 
-    ASSERT_TRUE(result.is_err());
     print_error_msg(result, __LINE__);
+    ASSERT_TRUE(result.is_err());
 
     // -------------------------------------------------------------------------
 
@@ -1792,8 +1792,8 @@ TEST(TestParser, ParseAutoindexDirective) {
     current = tokens.begin();
     result = ParserTestFriend::parse_autoindex_directive(&current, tokens.end(), &actual);
 
-    ASSERT_TRUE(result.is_err());
     print_error_msg(result, __LINE__);
+    ASSERT_TRUE(result.is_err());
 }
 
 
@@ -1801,7 +1801,7 @@ TEST(TestParser, ParseBodySizeDirective) {
     const std::string test_directive = "test_autoindex";
     std::size_t expected, actual;
     Result<int, std::string> result;
-    TokenConstItr current;
+    TokenItr current;
     std::deque<Token> tokens;
     int cnt;
 
@@ -1986,8 +1986,8 @@ TEST(TestParser, ParseBodySizeDirective) {
     current = tokens.begin();
     result = ParserTestFriend::parse_body_size_directive(&current, tokens.end(), &actual);
 
-    ASSERT_TRUE(result.is_err());
     print_error_msg(result, __LINE__);
+    ASSERT_TRUE(result.is_err());
 
     // -------------------------------------------------------------------------
 
@@ -1998,8 +1998,8 @@ TEST(TestParser, ParseBodySizeDirective) {
     current = tokens.begin();
     result = ParserTestFriend::parse_body_size_directive(&current, tokens.end(), &actual);
 
-    ASSERT_TRUE(result.is_err());
     print_error_msg(result, __LINE__);
+    ASSERT_TRUE(result.is_err());
 
     // -------------------------------------------------------------------------
 
@@ -2011,8 +2011,8 @@ TEST(TestParser, ParseBodySizeDirective) {
     current = tokens.begin();
     result = ParserTestFriend::parse_body_size_directive(&current, tokens.end(), &actual);
 
-    ASSERT_TRUE(result.is_err());
     print_error_msg(result, __LINE__);
+    ASSERT_TRUE(result.is_err());
 
     // -------------------------------------------------------------------------
 
@@ -2024,8 +2024,8 @@ TEST(TestParser, ParseBodySizeDirective) {
     current = tokens.begin();
     result = ParserTestFriend::parse_body_size_directive(&current, tokens.end(), &actual);
 
-    ASSERT_TRUE(result.is_err());
     print_error_msg(result, __LINE__);
+    ASSERT_TRUE(result.is_err());
 
     // -------------------------------------------------------------------------
 
@@ -2039,8 +2039,8 @@ TEST(TestParser, ParseBodySizeDirective) {
     current = tokens.begin();
     result = ParserTestFriend::parse_body_size_directive(&current, tokens.end(), &actual);
 
-    ASSERT_TRUE(result.is_err());
     print_error_msg(result, __LINE__);
+    ASSERT_TRUE(result.is_err());
 
     // -------------------------------------------------------------------------
 
@@ -2052,8 +2052,8 @@ TEST(TestParser, ParseBodySizeDirective) {
     current = tokens.begin();
     result = ParserTestFriend::parse_body_size_directive(&current, tokens.end(), &actual);
 
-    ASSERT_TRUE(result.is_err());
     print_error_msg(result, __LINE__);
+    ASSERT_TRUE(result.is_err());
 
     // -------------------------------------------------------------------------
 
@@ -2065,8 +2065,8 @@ TEST(TestParser, ParseBodySizeDirective) {
     current = tokens.begin();
     result = ParserTestFriend::parse_body_size_directive(&current, tokens.end(), &actual);
 
-    ASSERT_TRUE(result.is_err());
     print_error_msg(result, __LINE__);
+    ASSERT_TRUE(result.is_err());
 
     // -------------------------------------------------------------------------
 
@@ -2078,8 +2078,8 @@ TEST(TestParser, ParseBodySizeDirective) {
     current = tokens.begin();
     result = ParserTestFriend::parse_body_size_directive(&current, tokens.end(), &actual);
 
-    ASSERT_TRUE(result.is_err());
     print_error_msg(result, __LINE__);
+    ASSERT_TRUE(result.is_err());
 
     // -------------------------------------------------------------------------
 
@@ -2091,8 +2091,8 @@ TEST(TestParser, ParseBodySizeDirective) {
     current = tokens.begin();
     result = ParserTestFriend::parse_body_size_directive(&current, tokens.end(), &actual);
 
-    ASSERT_TRUE(result.is_err());
     print_error_msg(result, __LINE__);
+    ASSERT_TRUE(result.is_err());
 
     // -------------------------------------------------------------------------
 
@@ -2104,8 +2104,8 @@ TEST(TestParser, ParseBodySizeDirective) {
     current = tokens.begin();
     result = ParserTestFriend::parse_body_size_directive(&current, tokens.end(), &actual);
 
-    ASSERT_TRUE(result.is_err());
     print_error_msg(result, __LINE__);
+    ASSERT_TRUE(result.is_err());
 
     // -------------------------------------------------------------------------
 
@@ -2117,8 +2117,8 @@ TEST(TestParser, ParseBodySizeDirective) {
     current = tokens.begin();
     result = ParserTestFriend::parse_body_size_directive(&current, tokens.end(), &actual);
 
-    ASSERT_TRUE(result.is_err());
     print_error_msg(result, __LINE__);
+    ASSERT_TRUE(result.is_err());
 }
 
 
@@ -2128,7 +2128,7 @@ TEST(TestParser, ParseBodySizeDirective) {
 TEST(TestParser, ParseDefaultConfig) {
     std::deque<Token> tokens;
     DefaultConfig expected, actual;
-    TokenConstItr current;
+    TokenItr current;
     Result<int, std::string> result;
     int cnt;
 
@@ -2286,8 +2286,8 @@ TEST(TestParser, ParseDefaultConfig) {
 
     result = ParserTestFriend::parse_default_config(&current, tokens.end(), &actual);
 
-    ASSERT_TRUE(result.is_err());
     print_error_msg(result, __LINE__);
+    ASSERT_TRUE(result.is_err());
 
     // -------------------------------------------------------------------------
 
@@ -2309,8 +2309,8 @@ TEST(TestParser, ParseDefaultConfig) {
 
     result = ParserTestFriend::parse_default_config(&current, tokens.end(), &actual);
 
-    ASSERT_TRUE(result.is_err());
     print_error_msg(result, __LINE__);
+    ASSERT_TRUE(result.is_err());
 
     // -------------------------------------------------------------------------
 
@@ -2333,8 +2333,8 @@ TEST(TestParser, ParseDefaultConfig) {
 
     result = ParserTestFriend::parse_default_config(&current, tokens.end(), &actual);
 
-    ASSERT_TRUE(result.is_err());
     print_error_msg(result, __LINE__);
+    ASSERT_TRUE(result.is_err());
 
     // -------------------------------------------------------------------------
 
@@ -2358,8 +2358,8 @@ TEST(TestParser, ParseDefaultConfig) {
 
     result = ParserTestFriend::parse_default_config(&current, tokens.end(), &actual);
 
-    ASSERT_TRUE(result.is_err());
     print_error_msg(result, __LINE__);
+    ASSERT_TRUE(result.is_err());
 
     // -------------------------------------------------------------------------
 
@@ -2377,8 +2377,8 @@ TEST(TestParser, ParseDefaultConfig) {
 
     result = ParserTestFriend::parse_default_config(&current, tokens.end(), &actual);
 
-    ASSERT_TRUE(result.is_err());
     print_error_msg(result, __LINE__);
+    ASSERT_TRUE(result.is_err());
 
     // -------------------------------------------------------------------------
 
@@ -2393,8 +2393,8 @@ TEST(TestParser, ParseDefaultConfig) {
 
     result = ParserTestFriend::parse_default_config(&current, tokens.end(), &actual);
 
-    ASSERT_TRUE(result.is_err());
     print_error_msg(result, __LINE__);
+    ASSERT_TRUE(result.is_err());
 
     // -------------------------------------------------------------------------
 
@@ -2408,15 +2408,15 @@ TEST(TestParser, ParseDefaultConfig) {
 
     result = ParserTestFriend::parse_default_config(&current, tokens.end(), &actual);
 
-    ASSERT_TRUE(result.is_err());
     print_error_msg(result, __LINE__);
+    ASSERT_TRUE(result.is_err());
 
 }
 
 
 TEST(TestParser, ParseLocationPath) {
     std::deque<Token> tokens;
-    TokenConstItr current;
+    TokenItr current;
     Result<std::string, std::string> result;
     std::string expected, actual;
     int cnt;
@@ -2493,8 +2493,8 @@ TEST(TestParser, ParseLocationPath) {
 
     result = ParserTestFriend::parse_location_path(&current, tokens.end());
 
-    ASSERT_TRUE(result.is_err());
     print_error_msg(result, __LINE__);
+    ASSERT_TRUE(result.is_err());
 
     // -------------------------------------------------------------------------
 
@@ -2505,8 +2505,8 @@ TEST(TestParser, ParseLocationPath) {
 
     result = ParserTestFriend::parse_location_path(&current, tokens.end());
 
-    ASSERT_TRUE(result.is_err());
     print_error_msg(result, __LINE__);
+    ASSERT_TRUE(result.is_err());
 
     // -------------------------------------------------------------------------
 
@@ -2518,8 +2518,8 @@ TEST(TestParser, ParseLocationPath) {
 
     result = ParserTestFriend::parse_location_path(&current, tokens.end());
 
-    ASSERT_TRUE(result.is_err());
     print_error_msg(result, __LINE__);
+    ASSERT_TRUE(result.is_err());
 
     // -------------------------------------------------------------------------
 
@@ -2531,8 +2531,8 @@ TEST(TestParser, ParseLocationPath) {
 
     result = ParserTestFriend::parse_location_path(&current, tokens.end());
 
-    ASSERT_TRUE(result.is_err());
     print_error_msg(result, __LINE__);
+    ASSERT_TRUE(result.is_err());
 
     // -------------------------------------------------------------------------
 
@@ -2544,8 +2544,8 @@ TEST(TestParser, ParseLocationPath) {
 
     result = ParserTestFriend::parse_location_path(&current, tokens.end());
 
-    ASSERT_TRUE(result.is_err());
     print_error_msg(result, __LINE__);
+    ASSERT_TRUE(result.is_err());
 
     // -------------------------------------------------------------------------
     tokens = {};
@@ -2556,8 +2556,8 @@ TEST(TestParser, ParseLocationPath) {
 
     result = ParserTestFriend::parse_location_path(&current, tokens.end());
 
-    ASSERT_TRUE(result.is_err());
     print_error_msg(result, __LINE__);
+    ASSERT_TRUE(result.is_err());
 
     // -------------------------------------------------------------------------
 
@@ -2568,8 +2568,8 @@ TEST(TestParser, ParseLocationPath) {
 
     result = ParserTestFriend::parse_location_path(&current, tokens.end());
 
-    ASSERT_TRUE(result.is_err());
     print_error_msg(result, __LINE__);
+    ASSERT_TRUE(result.is_err());
 
     // -------------------------------------------------------------------------
 
@@ -2580,8 +2580,8 @@ TEST(TestParser, ParseLocationPath) {
 
     result = ParserTestFriend::parse_location_path(&current, tokens.end());
 
-    ASSERT_TRUE(result.is_err());
     print_error_msg(result, __LINE__);
+    ASSERT_TRUE(result.is_err());
 
     // -------------------------------------------------------------------------
 
@@ -2594,8 +2594,8 @@ TEST(TestParser, ParseLocationPath) {
 
     result = ParserTestFriend::parse_location_path(&current, tokens.end());
 
-    ASSERT_TRUE(result.is_err());
     print_error_msg(result, __LINE__);
+    ASSERT_TRUE(result.is_err());
 
     // -------------------------------------------------------------------------
 
@@ -2607,49 +2607,39 @@ TEST(TestParser, ParseLocationPath) {
 
     result = ParserTestFriend::parse_location_path(&current, tokens.end());
 
-    ASSERT_TRUE(result.is_err());
     print_error_msg(result, __LINE__);
+    ASSERT_TRUE(result.is_err());
 
 }
 
 // "location"  path  "{"  directive_name ... "}"
-// ^current
-TEST(TestParser, ParseLocation) {
+//                        ^current
+TEST(TestParser, ParseLocationBlock) {
     std::deque<Token> tokens;
-    std::map<std::string, LocationConfig> expected, actual;
-    LocationConfig location_config;
-    TokenConstItr current;
+    LocationConfig expected, actual;
+    TokenItr current;
     Result<int, std::string> result;
     int cnt;
 
 
     cnt = 0;
     tokens = {};
-    tokens.push_back(Token("location",   kTokenKindBlockName, ++cnt));
-    tokens.push_back(Token("/",          kTokenKindBlockParam, ++cnt));
-    tokens.push_back(Token("{",          kTokenKindBraces, ++cnt));
     tokens.push_back(Token("}",          kTokenKindBraces, ++cnt));
 
     current = tokens.begin();
 
-    location_config = {};
     expected = {};
-    expected["/"] = location_config;
 
     actual = {};
-    result = ParserTestFriend::parse_location(&current, tokens.end(), &actual);
+    result = ParserTestFriend::parse_location_block(&current, tokens.end(), &actual);
 
     ASSERT_TRUE(result.is_ok());
-    expect_eq_locations(expected, actual, __LINE__);
+    expect_eq_location_config(expected, actual, __LINE__);
 
     // -------------------------------------------------------------------------
 
     cnt = 0;
     tokens = {};
-    tokens.push_back(Token("location",      kTokenKindBlockName, ++cnt));
-    tokens.push_back(Token("path",          kTokenKindBlockParam, ++cnt));
-    tokens.push_back(Token("{",             kTokenKindBraces, ++cnt));
-
     tokens.push_back(Token("root",          kTokenKindDirectiveName, ++cnt));
     tokens.push_back(Token("html",          kTokenKindDirectiveParam, ++cnt));
     tokens.push_back(Token(";",             kTokenKindSemicolin, ++cnt));
@@ -2677,32 +2667,23 @@ TEST(TestParser, ParseLocation) {
 
     current = tokens.begin();
 
-    location_config = {};
-    location_config.root_path = "html";
-    location_config.index_pages = {"index.html", "index.htm"};
-    location_config.limit_except.excluded_methods = {kGET};
-    location_config.autoindex = true;
-    location_config.max_body_size_bytes = 2 * ConfigInitValue::MB;
-
     expected = {};
-    expected["path"] = location_config;
+    expected.root_path = "html";
+    expected.index_pages = {"index.html", "index.htm"};
+    expected.limit_except.excluded_methods = {kGET};
+    expected.autoindex = true;
+    expected.max_body_size_bytes = 2 * ConfigInitValue::MB;
 
     actual = {};
-    result = ParserTestFriend::parse_location(&current, tokens.end(), &actual);
-
-    print_error_msg(result, __LINE__);
+    result = ParserTestFriend::parse_location_block(&current, tokens.end(), &actual);
 
     ASSERT_TRUE(result.is_ok());
-    expect_eq_locations(expected, actual, __LINE__);
+    expect_eq_location_config(expected, actual, __LINE__);
 
     // -------------------------------------------------------------------------
 
     cnt = 0;
     tokens = {};
-    tokens.push_back(Token("location",      kTokenKindBlockName, ++cnt));
-    tokens.push_back(Token("/old_page",     kTokenKindBlockParam, ++cnt));
-    tokens.push_back(Token("{",             kTokenKindBraces, ++cnt));
-
     tokens.push_back(Token("return",        kTokenKindDirectiveName, ++cnt));
     tokens.push_back(Token("301",           kTokenKindDirectiveParam, ++cnt));
     tokens.push_back(Token("/new_page",     kTokenKindDirectiveParam, ++cnt));
@@ -2729,81 +2710,58 @@ TEST(TestParser, ParseLocation) {
 
     current = tokens.begin();
 
-    location_config = {};
-    location_config.redirection.return_on = true;
-    location_config.redirection.code = 301;
-    location_config.redirection.text = "/new_page";
-    location_config.limit_except.excluded_methods = {kGET, kDELETE};
-    location_config.limit_except.rules.push_back(AccessRule(kDENY, "all"));
-
     expected = {};
-    expected["/old_page"] = location_config;
+    expected.redirection.return_on = true;
+    expected.redirection.code = 301;
+    expected.redirection.text = "/new_page";
+    expected.limit_except.excluded_methods = {kGET, kDELETE};
+    expected.limit_except.rules.push_back(AccessRule(kDENY, "all"));
 
     actual = {};
-    result = ParserTestFriend::parse_location(&current, tokens.end(), &actual);
+    result = ParserTestFriend::parse_location_block(&current, tokens.end(), &actual);
 
     ASSERT_TRUE(result.is_ok());
-    expect_eq_locations(expected, actual, __LINE__);
+    expect_eq_location_config(expected, actual, __LINE__);
 
 
     ////////////////////////////////////////////////////////////////////////////
 
-    cnt = 0;
-    tokens = {};
-
-    current = tokens.begin();
-
-
-    actual = {};
-    result = ParserTestFriend::parse_location(&current, tokens.end(), &actual);
-
-    ASSERT_TRUE(result.is_err());
-    print_error_msg(result, __LINE__);
-
-    // -------------------------------------------------------------------------
 
     cnt = 0;
     tokens = {};
-    tokens.push_back(Token("ng",        kTokenKindDirectiveParam, ++cnt));  // ng
-    tokens.push_back(Token("{",         kTokenKindBraces, ++cnt));
-
+    tokens.push_back(Token("{",         kTokenKindBraces, ++cnt));  // ng
     tokens.push_back(Token("}",         kTokenKindBraces, ++cnt));
 
     current = tokens.begin();
 
 
     actual = {};
-    result = ParserTestFriend::parse_location(&current, tokens.end(), &actual);
+    result = ParserTestFriend::parse_location_block(&current, tokens.end(), &actual);
 
-    ASSERT_TRUE(result.is_err());
     print_error_msg(result, __LINE__);
+    ASSERT_TRUE(result.is_err());
 
     // -------------------------------------------------------------------------
 
     cnt = 0;
     tokens = {};
-    tokens.push_back(Token("location",  kTokenKindBlockName, ++cnt));
-    tokens.push_back(Token("{",         kTokenKindBraces, ++cnt));
+    tokens.push_back(Token(";",         kTokenKindSemicolin, ++cnt));    // ng
     tokens.push_back(Token("}",         kTokenKindBraces, ++cnt));
 
     current = tokens.begin();
 
 
     actual = {};
-    result = ParserTestFriend::parse_location(&current, tokens.end(), &actual);
+    result = ParserTestFriend::parse_location_block(&current, tokens.end(), &actual);
 
-    ASSERT_TRUE(result.is_err());
     print_error_msg(result, __LINE__);
+    ASSERT_TRUE(result.is_err());
 
     // -------------------------------------------------------------------------
 
 
     cnt = 0;
     tokens = {};
-    tokens.push_back(Token("location",  kTokenKindBlockName, ++cnt));
-    tokens.push_back(Token("/path",     kTokenKindBlockParam, ++cnt));
-    tokens.push_back(Token("{",         kTokenKindBraces, ++cnt));
-
     tokens.push_back(Token("listen",    kTokenKindDirectiveName, ++cnt));  // ng
     tokens.push_back(Token("8080",      kTokenKindDirectiveParam, ++cnt));
     tokens.push_back(Token(";",         kTokenKindSemicolin, ++cnt));
@@ -2814,100 +2772,15 @@ TEST(TestParser, ParseLocation) {
 
 
     actual = {};
-    result = ParserTestFriend::parse_location(&current, tokens.end(), &actual);
+    result = ParserTestFriend::parse_location_block(&current, tokens.end(), &actual);
 
-    ASSERT_TRUE(result.is_err());
     print_error_msg(result, __LINE__);
+    ASSERT_TRUE(result.is_err());
 
     // -------------------------------------------------------------------------
 
     cnt = 0;
     tokens = {};
-    tokens.push_back(Token("/path",     kTokenKindBlockParam, ++cnt));
-    tokens.push_back(Token("ng",        kTokenKindDirectiveParam, ++cnt));  // ng
-    tokens.push_back(Token("{",         kTokenKindBraces, ++cnt));
-
-    tokens.push_back(Token("}",         kTokenKindBraces, ++cnt));
-
-    current = tokens.begin();
-
-
-    actual = {};
-    result = ParserTestFriend::parse_location(&current, tokens.end(), &actual);
-
-    ASSERT_TRUE(result.is_err());
-    print_error_msg(result, __LINE__);
-
-    // -------------------------------------------------------------------------
-
-    cnt = 0;
-    tokens = {};
-    tokens.push_back(Token("location",  kTokenKindBlockName, ++cnt));
-    tokens.push_back(Token("/path",     kTokenKindBlockParam, ++cnt));
-    tokens.push_back(Token(";",         kTokenKindSemicolin, ++cnt));  // ng
-    tokens.push_back(Token("{",         kTokenKindBraces, ++cnt));
-
-    tokens.push_back(Token("}",         kTokenKindBraces, ++cnt));
-
-    current = tokens.begin();
-
-
-    expected = {};
-    expected["/path"] = location_config;
-
-    actual = {};
-    result = ParserTestFriend::parse_location(&current, tokens.end(), &actual);
-
-    ASSERT_TRUE(result.is_err());
-    print_error_msg(result, __LINE__);
-
-    // -------------------------------------------------------------------------
-
-    cnt = 0;
-    tokens = {};
-    tokens.push_back(Token("location",  kTokenKindBlockName, ++cnt));
-    tokens.push_back(Token("/path",     kTokenKindDirectiveParam, ++cnt));
-
-    current = tokens.begin();
-
-    actual = {};
-    result = ParserTestFriend::parse_location(&current, tokens.end(), &actual);
-
-    ASSERT_TRUE(result.is_err());
-    print_error_msg(result, __LINE__);
-
-    // -------------------------------------------------------------------------
-
-    cnt = 0;
-    tokens = {};
-    tokens.push_back(Token("location",  kTokenKindBlockName, ++cnt));
-    tokens.push_back(Token("/path",     kTokenKindBlockParam, ++cnt));
-    tokens.push_back(Token("{",         kTokenKindBraces, ++cnt));
-
-    tokens.push_back(Token("location",  kTokenKindDirectiveName, ++cnt));  // ng
-    tokens.push_back(Token("xxx",       kTokenKindDirectiveParam, ++cnt));
-    tokens.push_back(Token("{",         kTokenKindBraces, ++cnt));
-    tokens.push_back(Token("}",         kTokenKindBraces, ++cnt));
-
-    tokens.push_back(Token("}",         kTokenKindBraces, ++cnt));
-
-    current = tokens.begin();
-
-
-    actual = {};
-    result = ParserTestFriend::parse_location(&current, tokens.end(), &actual);
-
-    ASSERT_TRUE(result.is_err());
-    print_error_msg(result, __LINE__);
-
-    // -------------------------------------------------------------------------
-
-    cnt = 0;
-    tokens = {};
-    tokens.push_back(Token("location",      kTokenKindBlockName, ++cnt));
-    tokens.push_back(Token("/path",         kTokenKindBlockParam, ++cnt));
-    tokens.push_back(Token("{",             kTokenKindBraces, ++cnt));
-
     tokens.push_back(Token("limit_except",  kTokenKindDirectiveName, ++cnt));
     tokens.push_back(Token("GET",           kTokenKindDirectiveParam, ++cnt));
     tokens.push_back(Token("DELETE",        kTokenKindDirectiveParam, ++cnt));
@@ -2926,24 +2799,15 @@ TEST(TestParser, ParseLocation) {
 
 
     actual = {};
-    result = ParserTestFriend::parse_location(&current, tokens.end(), &actual);
+    result = ParserTestFriend::parse_location_block(&current, tokens.end(), &actual);
 
-    ASSERT_TRUE(result.is_err());
     print_error_msg(result, __LINE__);
+    ASSERT_TRUE(result.is_err());
 
     // -------------------------------------------------------------------------
 
     cnt = 0;
     tokens = {};
-    tokens.push_back(Token("location",      kTokenKindBlockName, ++cnt));
-    tokens.push_back(Token("/path",         kTokenKindBlockParam, ++cnt));
-    tokens.push_back(Token("{",             kTokenKindBraces, ++cnt));
-
-    tokens.push_back(Token("limit_except",  kTokenKindDirectiveName, ++cnt));
-    tokens.push_back(Token("GET",           kTokenKindDirectiveParam, ++cnt));
-    tokens.push_back(Token("{",             kTokenKindBraces, ++cnt));
-    tokens.push_back(Token("}",             kTokenKindBraces, ++cnt));
-
     tokens.push_back(Token("limit_except",  kTokenKindDirectiveName, ++cnt));  // ng
     tokens.push_back(Token("DELETE",        kTokenKindDirectiveParam, ++cnt));
     tokens.push_back(Token(";",             kTokenKindSemicolin, ++cnt));
@@ -2954,10 +2818,10 @@ TEST(TestParser, ParseLocation) {
 
 
     actual = {};
-    result = ParserTestFriend::parse_location(&current, tokens.end(), &actual);
+    result = ParserTestFriend::parse_location_block(&current, tokens.end(), &actual);
 
-    ASSERT_TRUE(result.is_err());
     print_error_msg(result, __LINE__);
+    ASSERT_TRUE(result.is_err());
 
 }
 
@@ -2969,7 +2833,7 @@ TEST(TestParser, ParseServer) {
     ServerConfig expected, actual;
     LocationConfig location_config;
     ListenDirective listen;
-    TokenConstItr current;
+    TokenItr current;
     Result<int, std::string> result;
     int cnt;
 
@@ -3016,17 +2880,18 @@ TEST(TestParser, ParseServer) {
     tokens.push_back(Token("server",        kTokenKindBlockName, ++cnt));
     tokens.push_back(Token("{",             kTokenKindBraces, ++cnt));
 
-    tokens.push_back(Token("listen",        kTokenKindDirectiveName, ++cnt));           // server
-    tokens.push_back(Token("8080",          kTokenKindDirectiveParam, ++cnt));          // server
-    tokens.push_back(Token(";",             kTokenKindSemicolin, ++cnt));               // server
+    tokens.push_back(Token("listen",        kTokenKindDirectiveName, ++cnt));       // server
+    tokens.push_back(Token("8080",          kTokenKindDirectiveParam, ++cnt));      // server
+    tokens.push_back(Token(";",             kTokenKindSemicolin, ++cnt));           // server
 
-    tokens.push_back(Token("error_page",    kTokenKindDirectiveName, ++cnt));           // server
-    tokens.push_back(Token("400",           kTokenKindDirectiveParam, ++cnt));          // server
-    tokens.push_back(Token("server_error_page",kTokenKindDirectiveParam, ++cnt));   // server
-    tokens.push_back(Token(";",             kTokenKindSemicolin, ++cnt));               // server
+    tokens.push_back(Token("error_page",    kTokenKindDirectiveName, ++cnt));       // server
+    tokens.push_back(Token("400",           kTokenKindDirectiveParam, ++cnt));      // server
+    tokens.push_back(Token("404",           kTokenKindDirectiveParam, ++cnt));      // server
+    tokens.push_back(Token("server40x",     kTokenKindDirectiveParam, ++cnt));      // server
+    tokens.push_back(Token(";",             kTokenKindSemicolin, ++cnt));           // server
 
     tokens.push_back(Token("location",      kTokenKindBlockName, ++cnt));           // location
-    tokens.push_back(Token("/path",         kTokenKindBlockParam, ++cnt));      // location
+    tokens.push_back(Token("/path",         kTokenKindBlockParam, ++cnt));          // location
     tokens.push_back(Token("{",             kTokenKindBraces, ++cnt));              // location
 
     tokens.push_back(Token("root",          kTokenKindDirectiveName, ++cnt));       // location
@@ -3051,17 +2916,17 @@ TEST(TestParser, ParseServer) {
     tokens.push_back(Token("2m",            kTokenKindDirectiveParam, ++cnt));      // location
     tokens.push_back(Token(";",             kTokenKindSemicolin, ++cnt));           // location
 
-    tokens.push_back(Token("error_page",    kTokenKindDirectiveName, ++cnt));       // location
+    tokens.push_back(Token("error_page",    kTokenKindDirectiveName, ++cnt));       // location update server
     tokens.push_back(Token("404",           kTokenKindDirectiveParam, ++cnt));      // location
-    tokens.push_back(Token("/404.html",     kTokenKindDirectiveParam, ++cnt));      // location
+    tokens.push_back(Token("path404",       kTokenKindDirectiveParam, ++cnt));      // location
     tokens.push_back(Token(";",             kTokenKindSemicolin, ++cnt));           // location
 
-    tokens.push_back(Token("error_page",    kTokenKindDirectiveName, ++cnt));       // location
+    tokens.push_back(Token("error_page",    kTokenKindDirectiveName, ++cnt));       // location update server
     tokens.push_back(Token("500",           kTokenKindDirectiveParam, ++cnt));      // location
     tokens.push_back(Token("502",           kTokenKindDirectiveParam, ++cnt));      // location
     tokens.push_back(Token("503",           kTokenKindDirectiveParam, ++cnt));      // location
     tokens.push_back(Token("504",           kTokenKindDirectiveParam, ++cnt));      // location
-    tokens.push_back(Token("/50x.html",     kTokenKindDirectiveParam, ++cnt));      // location
+    tokens.push_back(Token("path50x",       kTokenKindDirectiveParam, ++cnt));      // location
     tokens.push_back(Token(";",             kTokenKindSemicolin, ++cnt));           // location
 
     tokens.push_back(Token("}",             kTokenKindBraces, ++cnt));              // location
@@ -3075,7 +2940,7 @@ TEST(TestParser, ParseServer) {
 
 
     tokens.push_back(Token("location",      kTokenKindBlockName, ++cnt));       // location
-    tokens.push_back(Token("/old_page",     kTokenKindBlockParam, ++cnt));  // location
+    tokens.push_back(Token("/old_page",     kTokenKindBlockParam, ++cnt));      // location
     tokens.push_back(Token("{",             kTokenKindBraces, ++cnt));          // location
 
     tokens.push_back(Token("return",        kTokenKindDirectiveName, ++cnt));   // location
@@ -3085,7 +2950,7 @@ TEST(TestParser, ParseServer) {
 
     tokens.push_back(Token("error_page",    kTokenKindDirectiveName, ++cnt));   // location
     tokens.push_back(Token("400",           kTokenKindDirectiveParam, ++cnt));  // location
-    tokens.push_back(Token("test_error",    kTokenKindDirectiveParam, ++cnt));  // location
+    tokens.push_back(Token("old400",        kTokenKindDirectiveParam, ++cnt));  // location
     tokens.push_back(Token(";",             kTokenKindSemicolin, ++cnt));       // location
 
     tokens.push_back(Token("}",             kTokenKindBraces, ++cnt));          // location
@@ -3098,7 +2963,7 @@ TEST(TestParser, ParseServer) {
 
     tokens.push_back(Token("error_page",    kTokenKindDirectiveName, ++cnt));   // server
     tokens.push_back(Token("599",           kTokenKindDirectiveParam, ++cnt));  // server
-    tokens.push_back(Token("error",         kTokenKindDirectiveParam, ++cnt));  // server
+    tokens.push_back(Token("server599",     kTokenKindDirectiveParam, ++cnt));  // server
     tokens.push_back(Token(";",             kTokenKindSemicolin, ++cnt));       // server
 
 
@@ -3113,35 +2978,80 @@ TEST(TestParser, ParseServer) {
     expected.server_names.insert("a");
     expected.server_names.insert("b");
     expected.error_pages = {
-        {400, "server_error_page"},
-        {599, "error"},
+        {400, "server40x"},
+        {404, "server40x"},
+        {599, "server599"},
     };
 
 
-    location_config = {};
+    location_config = LocationConfig(expected);
     location_config.root_path = "html";
     location_config.index_pages = {"index.html", "index.htm"};
     location_config.limit_except.excluded_methods = {kGET};
     location_config.autoindex = true;
     location_config.max_body_size_bytes = 2 * ConfigInitValue::MB;
     location_config.error_pages = {
-        {404, "/404.html"},
-        {500, "/50x.html"},
-        {502, "/50x.html"},
-        {503, "/50x.html"},
-        {504, "/50x.html"},
+        {400, "server40x"},
+        {404, "path404"},
+        {599, "server599"},
+        {500, "path50x"},
+        {502, "path50x"},
+        {503, "path50x"},
+        {504, "path50x"},
     };
     expected.locations["/path"] = location_config;
 
-    location_config = {};
+    location_config = LocationConfig(expected);
     location_config.redirection.return_on = true;
     location_config.redirection.code = 301;
     location_config.redirection.text = "/new_page";
     location_config.error_pages = {
-        {400, "test_error"},
+        {400, "old400"},
+        {404, "server40x"},
+        {599, "server599"},
     };
 
     expected.locations["/old_page"] = location_config;
+
+    actual = {};
+    result = ParserTestFriend::parse_server_block(&current, tokens.end(), &actual);
+
+    // print_error_msg(result, __LINE__);
+    ASSERT_TRUE(result.is_ok());
+    expect_eq_server_config(expected, actual, __LINE__);
+
+    // -------------------------------------------------------------------------
+
+    cnt = 0;
+    tokens = {};
+
+    tokens.push_back(Token("server",    kTokenKindBlockName, ++cnt));
+    tokens.push_back(Token("{",         kTokenKindBraces, ++cnt));
+
+    tokens.push_back(Token("location",  kTokenKindBlockName, ++cnt));
+    tokens.push_back(Token("/path",     kTokenKindBlockParam, ++cnt));
+    tokens.push_back(Token("{",         kTokenKindBraces, ++cnt));
+
+    tokens.push_back(Token("root",      kTokenKindDirectiveName, ++cnt));
+    tokens.push_back(Token("html",      kTokenKindDirectiveParam, ++cnt));  // default
+    tokens.push_back(Token(";",         kTokenKindSemicolin, ++cnt));
+
+    tokens.push_back(Token("}",         kTokenKindBraces, ++cnt));
+
+    tokens.push_back(Token("root",      kTokenKindDirectiveName, ++cnt));
+    tokens.push_back(Token("hoge",      kTokenKindDirectiveParam, ++cnt));  // change
+    tokens.push_back(Token(";",         kTokenKindSemicolin, ++cnt));
+
+    tokens.push_back(Token("}",         kTokenKindBraces, ++cnt));
+
+    current = tokens.begin();
+
+    expected = {};
+    expected.root_path = "hoge";
+
+    location_config = LocationConfig(expected);
+    location_config.root_path = "html";
+    expected.locations["/path"] = location_config;
 
     actual = {};
     result = ParserTestFriend::parse_server_block(&current, tokens.end(), &actual);
@@ -3192,8 +3102,8 @@ TEST(TestParser, ParseServer) {
     actual = {};
     result = ParserTestFriend::parse_server_block(&current, tokens.end(), &actual);
 
-    ASSERT_TRUE(result.is_err());
     print_error_msg(result, __LINE__);
+    ASSERT_TRUE(result.is_err());
 
     // -------------------------------------------------------------------------
 
@@ -3228,6 +3138,79 @@ TEST(TestParser, ParseServer) {
     actual = {};
     result = ParserTestFriend::parse_server_block(&current, tokens.end(), &actual);
 
-    ASSERT_TRUE(result.is_err());
     print_error_msg(result, __LINE__);
+    ASSERT_TRUE(result.is_err());
+
+    // -------------------------------------------------------------------------
+
+    cnt = 0;
+    tokens = {};
+
+    tokens.push_back(Token("server",    kTokenKindBlockName, ++cnt));
+    tokens.push_back(Token("{",         kTokenKindBraces, ++cnt));
+
+    tokens.push_back(Token("listen",    kTokenKindDirectiveName, ++cnt));
+    tokens.push_back(Token("8080",      kTokenKindDirectiveParam, ++cnt));
+    tokens.push_back(Token(";",         kTokenKindSemicolin, ++cnt));
+
+    tokens.push_back(Token("location",  kTokenKindBlockName, ++cnt));
+    tokens.push_back(Token("/path",     kTokenKindBlockParam, ++cnt));
+    tokens.push_back(Token("/path",     kTokenKindBlockParam, ++cnt));  // ng
+    tokens.push_back(Token("{",         kTokenKindBraces, ++cnt));
+
+    tokens.push_back(Token("root",      kTokenKindDirectiveName, ++cnt));
+    tokens.push_back(Token("html",      kTokenKindDirectiveParam, ++cnt));
+    tokens.push_back(Token(";",         kTokenKindSemicolin, ++cnt));
+
+    tokens.push_back(Token("}",         kTokenKindBraces, ++cnt));
+
+    tokens.push_back(Token("}",         kTokenKindBraces, ++cnt));
+
+    current = tokens.begin();
+
+    actual = {};
+    result = ParserTestFriend::parse_server_block(&current, tokens.end(), &actual);
+
+    print_error_msg(result, __LINE__);
+    ASSERT_TRUE(result.is_err());
+
+    // -------------------------------------------------------------------------
+
+    cnt = 0;
+    tokens = {};
+
+    tokens.push_back(Token("server",    kTokenKindBlockName, ++cnt));
+    tokens.push_back(Token("{",         kTokenKindBraces, ++cnt));
+
+    tokens.push_back(Token("listen",    kTokenKindDirectiveName, ++cnt));
+    tokens.push_back(Token("8080",      kTokenKindDirectiveParam, ++cnt));
+    tokens.push_back(Token(";",         kTokenKindSemicolin, ++cnt));
+
+    tokens.push_back(Token("location",  kTokenKindBlockName, ++cnt));
+    tokens.push_back(Token("a",         kTokenKindBlockParam, ++cnt));
+    tokens.push_back(Token("{",         kTokenKindBraces, ++cnt));
+
+    tokens.push_back(Token("root",      kTokenKindDirectiveName, ++cnt));
+    tokens.push_back(Token("html",      kTokenKindDirectiveParam, ++cnt));
+    tokens.push_back(Token(";",         kTokenKindSemicolin, ++cnt));
+
+    tokens.push_back(Token("location",  kTokenKindBlockName, ++cnt));  // ng
+    tokens.push_back(Token("b",         kTokenKindBlockParam, ++cnt));
+    tokens.push_back(Token("{",         kTokenKindBraces, ++cnt));
+
+    tokens.push_back(Token("}",         kTokenKindBraces, ++cnt));
+
+    tokens.push_back(Token("}",         kTokenKindBraces, ++cnt));
+
+    tokens.push_back(Token("}",         kTokenKindBraces, ++cnt));
+
+    current = tokens.begin();
+
+    actual = {};
+    result = ParserTestFriend::parse_server_block(&current, tokens.end(), &actual);
+
+    print_error_msg(result, __LINE__);
+    ASSERT_TRUE(result.is_err());
+
+
 }

--- a/test/unit_test/includes/TestParser.hpp
+++ b/test/unit_test/includes/TestParser.hpp
@@ -58,26 +58,26 @@ void debug_print(const std::string &msg, const std::size_t line);
 
 class ParserTestFriend : public ::testing::Test {
  public:
-    static Result<int, std::string> parse_directive_param(TokenConstItr *current,
-                                                          const TokenConstItr end,
+    static Result<int, std::string> parse_directive_param(TokenItr *current,
+                                                          const TokenItr end,
                                                           std::string *param,
                                                           const std::string &directive_name) {
         return Parser::parse_directive_param(current, end, param, directive_name);
     }
 
 
-    static Result<int, std::string> parse_directive_params(TokenConstItr *current,
-                                                           const TokenConstItr end,
+    static Result<int, std::string> parse_directive_params(TokenItr *current,
+                                                           const TokenItr end,
                                                            std::vector<std::string> *params,
                                                            const std::string &directive_name) {
         return Parser::parse_directive_params(current, end, params, directive_name);
     }
 
 
-    static Result<int, std::string> parse_set_params(TokenConstItr *current,
-                                                 const TokenConstItr end,
-                                                 std::set<std::string> *params,
-                                                 const std::string &name) {
+    static Result<int, std::string> parse_set_params(TokenItr *current,
+                                                     const TokenItr end,
+                                                     std::set<std::string> *params,
+                                                     const std::string &name) {
         return Parser::parse_set_params(current, end, params, name);
     }
 
@@ -87,75 +87,75 @@ class ParserTestFriend : public ::testing::Test {
     }
 
 
-    static Result<int, std::string> parse_listen_directive(TokenConstItr *current,
-                                                           const TokenConstItr end,
+    static Result<int, std::string> parse_listen_directive(TokenItr *current,
+                                                           const TokenItr end,
                                                            std::vector<ListenDirective> *listen_directives) {
         return Parser::parse_listen_directive(current, end, listen_directives);
     }
 
 
-    static Result<int, std::string> parse_return_directive(TokenConstItr *current,
-                                                          const TokenConstItr end,
-                                                          ReturnDirective *redirection) {
+    static Result<int, std::string> parse_return_directive(TokenItr *current,
+                                                           const TokenItr end,
+                                                           ReturnDirective *redirection) {
         return Parser::parse_return_directive(current, end, redirection);
     }
 
 
-    static Result<int, std::string> parse_root_directive(TokenConstItr *current,
-                                                         const TokenConstItr end,
+    static Result<int, std::string> parse_root_directive(TokenItr *current,
+                                                         const TokenItr end,
                                                          std::string *root_path) {
         return Parser::parse_root_directive(current, end, root_path);
     }
 
 
-    static Result<int, std::string> parse_limit_except_directive(TokenConstItr *current,
-                                                             const TokenConstItr end,
-                                                             LimitExceptDirective *limit_except) {
+    static Result<int, std::string> parse_limit_except_directive(TokenItr *current,
+                                                                 const TokenItr end,
+                                                                 LimitExceptDirective *limit_except) {
         return Parser::parse_limit_except_directive(current, end, limit_except);
     }
 
 
-    static Result<int, std::string> parse_error_page_directive(TokenConstItr *current,
-                                                               const TokenConstItr end,
+    static Result<int, std::string> parse_error_page_directive(TokenItr *current,
+                                                               const TokenItr end,
                                                                std::map<StatusCode, std::string> *error_pages) {
         return Parser::parse_error_page_directive(current, end, error_pages);
     }
 
 
-    static Result<int, std::string> parse_autoindex_directive(TokenConstItr *current,
-                                                          const TokenConstItr end,
-                                                          bool *autoindex) {
+    static Result<int, std::string> parse_autoindex_directive(TokenItr *current,
+                                                              const TokenItr end,
+                                                              bool *autoindex) {
         return Parser::parse_autoindex_directive(current, end, autoindex);
     }
 
 
-    static Result<int, std::string> parse_body_size_directive(TokenConstItr *current,
-                                                              const TokenConstItr end,
+    static Result<int, std::string> parse_body_size_directive(TokenItr *current,
+                                                              const TokenItr end,
                                                               std::size_t *max_body_size_bytes) {
         return Parser::parse_body_size_directive(current, end, max_body_size_bytes);
     }
 
 
-    static Result<int, std::string> parse_default_config(TokenConstItr *current,
-                                                         const TokenConstItr end,
+    static Result<int, std::string> parse_default_config(TokenItr *current,
+                                                         const TokenItr end,
                                                          DefaultConfig *default_config) {
         return Parser::parse_default_config(current, end, default_config);
     }
 
-    static Result<std::string, std::string> parse_location_path(TokenConstItr *current,
-                                                                const TokenConstItr end) {
+    static Result<std::string, std::string> parse_location_path(TokenItr *current,
+                                                                const TokenItr end) {
         return Parser::parse_location_path(current, end);
     }
 
-    static Result<int, std::string> parse_location(TokenConstItr *current,
-                                                   const TokenConstItr end,
-                                                   std::map<std::string, LocationConfig> *locations) {
-        return Parser::parse_location(current, end, locations);
+    static Result<int, std::string> parse_location_block(TokenItr *current,
+                                                         const TokenItr end,
+                                                         LocationConfig *location_config) {
+        return Parser::parse_location_block(current, end, location_config);
     }
 
 
-    static Result<int, std::string> parse_server_block(TokenConstItr *current,
-                                                       const TokenConstItr end,
+    static Result<int, std::string> parse_server_block(TokenItr *current,
+                                                       const TokenItr end,
                                                        ServerConfig *server_config) {
         return Parser::parse_server_block(current, end, server_config);
     }


### PR DESCRIPTION
LocationConfigをServerConfigで初期化するように変更

<hr>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- Webサーバーがデフォルトで提供するファイルに`index.html`と`index.htm`を追加しました。
- **バグ修正**
	- 特定のHTTPメソッドへのアクセスをIPアドレスに基づいて制限する新しいHTTPサーバー設定を導入しました。
- **リファクタリング**
	- コードレビューワークフローの名前を`ai-pr-reviewer`から`Code Review`に変更し、ワークフローのアクションを更新しました。
	- `ConfigStruct.hpp`において、`LocationConfig`構造体に新しいコンストラクタを追加し、初期化の柔軟性を向上させました。
	- 様々な関数シグネチャで`TokenConstItr`を`TokenItr`に置き換え、パーサーの内部処理を改善しました。
- **テスト**
	- 複数のテスト設定ファイルとユニットテストにおけるタイポの修正、コメントの追加、およびデバッグ用の機能を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->